### PR TITLE
Configure Jest to run existing unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dropbox-performance/ttvc",
-  "version": "0.0.2-1",
+  "version": "0.0.2-2",
   "description": "Measure Visually Complete metrics in real time",
   "repository": "git@github.com:dropbox/ttvc.git",
   "license": "MIT",


### PR DESCRIPTION
This pull request implements the minimum configuration I could manage such that we can run pre-existing unit tests without changing the test code.

These unit tests should also be picked up by our github actions workflow.

NOTE: Do we think it's worth splitting e2e tests and unit tests into separate github actions?  That will probably slow down the test jobs, but will give us slightly more granular feedback in Pull Requests.  We can always start simple and add more sophistication as we go, of course.