### PR TITLE
Publish to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,13 @@
 {
   "name": "@dropbox-performance/ttvc",
-  "version": "0.0.0",
+  "version": "0.0.1-0",
   "description": "Measure Visually Complete metrics in real time",
   "repository": "git@github.com:dropbox/ttvc.git",
   "license": "MIT",
   "module": "dist/index.js",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
This diff configures the package.json file for publication to npm.

- Adds the @dropbox-performance scope to the package name
- Adds a "module" entrypoint for ES2015 consumption
- Adds a "files" key to exclude all other files from the distributed artifacts
- Defines a "release" script using the library np (https://www.npmjs.com/package/np).

To release a new version:

```
$ npm login # authenticate with npm
$ npm run release -- [version]
```

To publish a test version (e.g. 0.0.2-2):

```
$ npm login # authenticate with npm
$ npm run release -- 0.0.2-2 --tag=test --any-branch 
```