### PR TITLE
build script always cleans artifacts first

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "access": "public"
   },
   "scripts": {
-    "clean": "rm -rf dist && rm -rf lib",
-    "build": "npm-run-all --parallel build:*",
+    "clean": "rimraf dist && rimraf lib",
+    "build": "npm-run-all clean --parallel build:*",
     "build:tsc": "tsc --project tsconfig.build.json",
     "build:rollup": "rollup --config rollup.config.js",
     "test": "npm-run-all build test:*",
@@ -51,6 +51,7 @@
     "prettier": "^2.5.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
+    "rimraf": "^3.0.2",
     "rollup": "^2.70.1",
     "rollup-plugin-terser": "^7.0.2",
     "ts-jest": "^27.1.4",


### PR DESCRIPTION
Also, use rimraf for OS portability