### PR TITLE
Move increment/decrement doc comments to index

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,5 +39,24 @@ export const init = (options?: TtvcOptions) => {
  */
 export const getTTVC = (callback: MetricSubscriber) => calculator?.getTTVC(callback);
 
+/**
+ * Call this to notify ttvc that an AJAX request has just begun.
+ *
+ * Instrument your site's AJAX requests with `incrementAjaxCount` and
+ * `decrementAjaxCount` to ensure that ttvc is not reported early.
+ *
+ * For the most accurate results, `decrementAjaxCount` should be called
+ * **exactly once** for each `incrementAjaxCount`.
+ */
 export const incrementAjaxCount = getNetworkIdleObservable().incrementAjaxCount;
+
+/**
+ * Call this to notify ttvc that an AJAX request has just resolved.
+ *
+ * Instrument your site's AJAX requests with `incrementAjaxCount` and
+ * `decrementAjaxCount` to ensure that ttvc is not reported early.
+ *
+ * For the most accurate results, `decrementAjaxCount` should be called
+ * **exactly once** for each `incrementAjaxCount`.
+ */
 export const decrementAjaxCount = getNetworkIdleObservable().decrementAjaxCount;

--- a/src/networkIdleObservable.ts
+++ b/src/networkIdleObservable.ts
@@ -268,20 +268,8 @@ export class NetworkIdleObservable {
     this.subscribers.forEach((subscriber) => subscriber(message));
   };
 
-  /**
-   * Call this to notify ttvc that an AJAX request has just begun.
-   *
-   * Instrument your site's AJAX requests with `incrementAjaxCount` and
-   * `decrementAjaxCount` to ensure that ttvc is not reported early.
-   */
   incrementAjaxCount = () => this.ajaxIdleObservable.increment();
 
-  /**
-   * Call this to notify ttvc that an AJAX request has just resolved.
-   *
-   * Instrument your site's AJAX requests with `incrementAjaxCount` and
-   * `decrementAjaxCount` to ensure that ttvc is not reported early.
-   */
   decrementAjaxCount = () => this.ajaxIdleObservable.decrement();
 
   isIdle = () => {


### PR DESCRIPTION
This is useful because it makes these comments available to consumers of the library.