### PR TITLE
Disallow `npm install`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test:unit": "jest",
     "test:e2e": "playwright test",
     "express": "node test/server/server.mjs",
+    "preinstall": "node scripts/ensure-yarn.js",
     "release": "np",
     "pretty": "prettier --write ."
   },

--- a/scripts/ensure-yarn.js
+++ b/scripts/ensure-yarn.js
@@ -1,0 +1,8 @@
+const agent = process.env.npm_config_user_agent;
+
+if (!agent?.startsWith('yarn')) {
+  console.error(
+    'Please use yarn to manage dependencies in this repository.\n  $ npm install --global yarn\n'
+  );
+  process.exit(1);
+}


### PR DESCRIPTION
This change is optional!

The idea is just to stop myself from accidentally forgetting which package manager the project uses and avoid committing _both_ `package-lock.json` and `yarn.lock` files.