### PR TITLE
PERF-784 img.complete not detected correctly in Chromium

### DIFF
--- a/src/networkIdleObservable.ts
+++ b/src/networkIdleObservable.ts
@@ -182,6 +182,7 @@ class ResourceLoadingIdleObservable {
   private add = (element: ResourceLoadingElement) => {
     // ignore elements without resources to load
     if (
+      (element instanceof HTMLImageElement && !element.src) ||
       (element instanceof HTMLImageElement && element.complete) ||
       (element instanceof HTMLLinkElement && !element.href) ||
       (element instanceof HTMLScriptElement && !element.src) ||

--- a/src/networkIdleObservable.ts
+++ b/src/networkIdleObservable.ts
@@ -180,7 +180,6 @@ class ResourceLoadingIdleObservable {
   };
 
   private add = (element: ResourceLoadingElement) => {
-    this.startCleanupTimeout();
     // ignore elements without resources to load
     if (
       (element instanceof HTMLImageElement && element.complete) ||
@@ -191,6 +190,7 @@ class ResourceLoadingIdleObservable {
       return;
     }
 
+    this.startCleanupTimeout();
     if (this.pendingResources.size === 0) {
       this.next('BUSY');
     }

--- a/test/e2e/images6/index.html
+++ b/test/e2e/images6/index.html
@@ -1,5 +1,4 @@
 <head>
-  <!-- <script>window.NETWORK_TIMEOUT = 10000</script> -->
   <script src="/dist/index.min.js"></script>
   <script src="/analytics.js"></script>
 </head>

--- a/test/e2e/images6/index.html
+++ b/test/e2e/images6/index.html
@@ -1,0 +1,22 @@
+<head>
+  <!-- <script>window.NETWORK_TIMEOUT = 10000</script> -->
+  <script src="/dist/index.min.js"></script>
+  <script src="/analytics.js"></script>
+</head>
+
+<body>
+  <img />
+
+  <script>
+    // Remove and re-append an image that has no source.
+    // Chromium seems to get confused and report `img.complete = false` in this scenario.
+    window.addEventListener('load', () => {
+      const img = document.querySelector('img');
+      console.log('img.complete =', img.complete);
+
+      img.remove();
+      document.body.appendChild(img);
+      console.log('img.complete =', img.complete);
+    });
+  </script>
+</body>

--- a/test/e2e/images6/index.spec.ts
+++ b/test/e2e/images6/index.spec.ts
@@ -1,0 +1,26 @@
+import {test, expect} from '@playwright/test';
+
+import {FUDGE} from '../../util/constants';
+import {getEntries, entryCountIs} from '../../util/entries';
+
+const PAGELOAD_DELAY = 1000;
+
+test.describe('TTVC', () => {
+  test('an image without src, removed and re-appended', async ({page}) => {
+    await page.goto(`/test/images6?delay=${PAGELOAD_DELAY}`, {
+      waitUntil: 'networkidle',
+    });
+
+    await entryCountIs(page, 1);
+
+    const entries = await getEntries(page);
+
+    expect(entries.length).toBe(1);
+    expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY);
+    expect(entries[0].duration).toBeLessThanOrEqual(PAGELOAD_DELAY + FUDGE);
+
+    // this assertion highlights an issue observed in the following chromium version.
+    // Chromium: 101.0.4951.67 (Official Build) (arm64)
+    expect(entries[0].detail.didNetworkTimeOut).toBe(false);
+  });
+});


### PR DESCRIPTION
It seems like `img.complete` isn't exactly what you might expect in this edge case, in Chromium.