### PR TITLE
Omit measurements larger than MAX_SAFE_INTEGER

### DIFF
--- a/src/visuallyCompleteCalculator.ts
+++ b/src/visuallyCompleteCalculator.ts
@@ -121,6 +121,17 @@ class VisuallyCompleteCalculator {
   }
 
   private next(measurement: Metric) {
+    if (measurement.end > Number.MAX_SAFE_INTEGER) {
+      Logger.warn(
+        'VisuallyCompleteCalculator.next()',
+        '::',
+        'This browser reported a time larger than MAX_SAFE_INTEGER. We are ignoring it.',
+        '::',
+        measurement
+      );
+      return;
+    }
+
     Logger.debug(
       'VisuallyCompleteCalculator.next()',
       '::',


### PR DESCRIPTION
Some browsers (esp. Firefox) appear to report unreasonable timestamps for unknown reasons.  This doesn't seem like it can be valid data, so maybe we should help normalize the data by omitting those measurements?