### PR TITLE
Test against mobile browsers (only on CI)

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -64,20 +64,6 @@ const config: PlaywrightTestConfig = {
       },
     },
 
-    /* Test against mobile viewports. */
-    // {
-    //   name: 'Mobile Chrome',
-    //   use: {
-    //     ...devices['Pixel 5'],
-    //   },
-    // },
-    // {
-    //   name: 'Mobile Safari',
-    //   use: {
-    //     ...devices['iPhone 12'],
-    //   },
-    // },
-
     /* Test against branded browsers. */
     // {
     //   name: 'Microsoft Edge',
@@ -102,5 +88,23 @@ const config: PlaywrightTestConfig = {
     port: 3001,
   },
 };
+
+if (process.env.CI) {
+  config.projects?.push(
+    /* Test against mobile viewports (CI only). */
+    {
+      name: 'Mobile Chrome',
+      use: {
+        ...devices['Pixel 5'],
+      },
+    },
+    {
+      name: 'Mobile Safari',
+      use: {
+        ...devices['iPhone 12'],
+      },
+    }
+  );
+}
 
 export default config;

--- a/test/e2e/interaction3/index.spec.ts
+++ b/test/e2e/interaction3/index.spec.ts
@@ -6,7 +6,9 @@ import {getEntries, entryCountIs} from '../../util/entries';
 const PAGELOAD_DELAY = 500;
 
 test.describe('TTVC', () => {
-  test('an user scrolls', async ({page}) => {
+  test('an user scrolls', async ({page, isMobile}) => {
+    test.skip(Boolean(isMobile), 'wheel events are not defined for mobile devices');
+
     await page.goto(`/test/interaction3?delay=${PAGELOAD_DELAY}`, {});
 
     await page.mouse.wheel(0, 2000);

--- a/test/e2e/interaction3/index.spec.ts
+++ b/test/e2e/interaction3/index.spec.ts
@@ -6,7 +6,7 @@ import {getEntries, entryCountIs} from '../../util/entries';
 const PAGELOAD_DELAY = 500;
 
 test.describe('TTVC', () => {
-  test('an user scrolls', async ({page, isMobile}) => {
+  test('a user scrolls', async ({page, isMobile}) => {
     test.skip(Boolean(isMobile), 'wheel events are not defined for mobile devices');
 
     await page.goto(`/test/interaction3?delay=${PAGELOAD_DELAY}`, {});


### PR DESCRIPTION
Run our end-to-end test suite against mobile browsers.  We only run this on CI so that local testing doesn't get too bogged down.