### PR TITLE
PERF-795 recognize contributors via AUTHORS file

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,1 @@
+Andrew Hyndman <ajhyndman@hotmail.com>


### PR DESCRIPTION
We especially want to be able to highlight some contributions that occurred prior to extracting this library  as an open source project.

The AUTHORS file appears to be a fairly standardized means of doing so.

https://opensource.google/documentation/reference/releasing/authors
https://github.com/facebook/react/blob/main/AUTHORS

I am adding myself for now, and will invite others to include themselves in this list!