### PR TITLE
Try out some different README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,10 @@
 ![version](https://img.shields.io/npm/v/@dropbox/ttvc)
 ![downloads](https://img.shields.io/npm/dt/@dropbox/ttvc)
 ![minzip size](https://img.shields.io/bundlephobia/minzip/@dropbox/ttvc)
-![min size](https://img.shields.io/bundlephobia/min/@dropbox/ttvc)
-![checks](https://img.shields.io/github/checks-status/dropbox/ttvc/main)
+
+![lint](https://img.shields.io/github/workflow/status/dropbox/ttvc/Lint/main?label=lint)
+![unit](https://img.shields.io/github/workflow/status/dropbox/ttvc/Unit%20Tests/main?label=unit)
+![playwright](https://img.shields.io/github/workflow/status/dropbox/ttvc/Playwright%20Tests/main?label=playwright)
 
 - [Overview](#overview)
 - [Get started](#get-started)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # `ttvc`
 
 ![version](https://img.shields.io/npm/v/@dropbox/ttvc)
-![downloads](https://img.shields.io/npm/dt/@dropbox/ttvc)
 ![minzip size](https://img.shields.io/bundlephobia/minzip/@dropbox/ttvc)
 
 ![lint](https://img.shields.io/github/workflow/status/dropbox/ttvc/Lint/main?label=lint)


### PR DESCRIPTION
Despite our patience, it doesn't appear that the github "checks" badge works for branches!  Instead, I replaced it with one badge each for our individual workflows.

There were a lot of badges at this point, so I also removed the npm downloads count.  It's cool, but I'm not sure it's that important to highlight here.  😛 