### PR TITLE
Revert "Disallow npm usage"

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "test:unit": "jest",
     "test:e2e": "playwright test",
     "express": "node test/server/server.mjs",
-    "preinstall": "node scripts/ensure-yarn.js",
     "release": "np",
     "pretty": "prettier --write ."
   },

--- a/scripts/ensure-yarn.js
+++ b/scripts/ensure-yarn.js
@@ -1,8 +1,0 @@
-const agent = process.env.npm_config_user_agent;
-
-if (!agent?.startsWith('yarn')) {
-  console.error(
-    'Please use yarn to manage dependencies in this repository.\n  $ npm install --global yarn\n'
-  );
-  process.exit(1);
-}


### PR DESCRIPTION
It seems that our pre-install hook isn't safe.  This runs when a package is installed in production, preventing use by some consumers.

I think the project I took this idea from was using workspaces.  This means they could specify this hook in the repo root package without impacting the published npm packages.  We can't get away with the same here.

Fixes #60 