### PR TITLE
PERF-813 Capture diagnostic details

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,11 @@ export type Metric = {
   detail: {
     // if ttvc ignored a stalled network request, this value will be true
     didNetworkTimeOut: boolean;
+
+    // the most recent visible update
+    // (this can be either a mutation or a load event target, whichever
+    // occurred last)
+    lastVisibleChange?: HTMLElement | TimestampedMutationRecord;
   };
 };
 ```

--- a/src/inViewportImageObserver.ts
+++ b/src/inViewportImageObserver.ts
@@ -21,11 +21,11 @@ import {Logger} from './util/logger';
 export class InViewportImageObserver {
   private intersectionObserver: IntersectionObserver;
   private imageLoadTimes = new Map<HTMLImageElement | HTMLIFrameElement, number>();
-  private callback: (timestamp: number) => void;
+  private callback: (timestamp: number, img: HTMLImageElement | HTMLIFrameElement) => void;
 
   public lastImageLoadTimestamp = 0;
 
-  constructor(callback: (timestamp: number) => void) {
+  constructor(callback: (timestamp: number, img: HTMLElement) => void) {
     this.callback = callback;
     this.intersectionObserver = new IntersectionObserver(this.intersectionObserverCallback);
   }
@@ -36,7 +36,7 @@ export class InViewportImageObserver {
       const timestamp = this.imageLoadTimes.get(img);
       if (entry.isIntersecting && timestamp != null) {
         Logger.info('InViewportImageObserver.callback()', '::', 'timestamp =', timestamp);
-        this.callback(timestamp);
+        this.callback(timestamp, img);
       }
       this.intersectionObserver.unobserve(img);
       this.imageLoadTimes.delete(img);

--- a/src/visuallyCompleteCalculator.ts
+++ b/src/visuallyCompleteCalculator.ts
@@ -63,7 +63,7 @@ class VisuallyCompleteCalculator {
     }
 
     this.inViewportMutationObserver = new InViewportMutationObserver((mutation) => {
-      if (mutation.timestamp ?? 0 >= (this.lastMutation?.timestamp ?? 0)) {
+      if ((mutation.timestamp ?? 0) >= (this.lastMutation?.timestamp ?? 0)) {
         this.lastMutation = mutation;
       }
     });

--- a/src/visuallyCompleteCalculator.ts
+++ b/src/visuallyCompleteCalculator.ts
@@ -21,7 +21,7 @@ export type Metric = {
     didNetworkTimeOut: boolean;
 
     // the most recent visual update; this can be either a mutation or a load event target
-    lastVisualUpdate?: HTMLElement | TimestampedMutationRecord;
+    lastVisibleChange?: HTMLElement | TimestampedMutationRecord;
   };
 };
 
@@ -116,7 +116,7 @@ class VisuallyCompleteCalculator {
         duration: end - start,
         detail: {
           didNetworkTimeOut,
-          lastVisualUpdate:
+          lastVisibleChange:
             this.lastImageLoadTimestamp > (this.lastMutation?.timestamp ?? 0)
               ? this.lastImageLoadTarget
               : this.lastMutation,

--- a/src/visuallyCompleteCalculator.ts
+++ b/src/visuallyCompleteCalculator.ts
@@ -19,9 +19,9 @@ export type Metric = {
   detail: {
     // if ttvc ignored a stalled network request, this value will be true
     didNetworkTimeOut: boolean;
-    lastImageLoadTimestamp: number;
-    lastImageLoadTarget?: HTMLElement;
-    lastMutation?: TimestampedMutationRecord;
+
+    // the most recent visual update; this can be either a mutation or a load event target
+    lastVisualUpdate?: HTMLElement | TimestampedMutationRecord;
   };
 };
 
@@ -116,9 +116,10 @@ class VisuallyCompleteCalculator {
         duration: end - start,
         detail: {
           didNetworkTimeOut,
-          lastImageLoadTimestamp: this.lastImageLoadTimestamp,
-          lastImageLoadTarget: this.lastImageLoadTarget,
-          lastMutation: this.lastMutation,
+          lastVisualUpdate:
+            this.lastImageLoadTimestamp > (this.lastMutation?.timestamp ?? 0)
+              ? this.lastImageLoadTarget
+              : this.lastMutation,
         },
       });
     }

--- a/test/e2e/output1/index.html
+++ b/test/e2e/output1/index.html
@@ -1,0 +1,9 @@
+<head>
+  <script src="/dist/index.min.js"></script>
+  <script src="/analytics.js"></script>
+</head>
+
+<body>
+  <h1 id="h1">Hello world!</h1>
+  <img src="/150.png?delay=500" />
+</body>

--- a/test/e2e/output1/index.spec.ts
+++ b/test/e2e/output1/index.spec.ts
@@ -1,0 +1,38 @@
+import {test, expect} from '@playwright/test';
+
+import {FUDGE} from '../../util/constants';
+import {getEntries} from '../../util/entries';
+
+const PAGELOAD_DELAY = 200;
+const IMAGE_DELAY = 500;
+
+test.describe('TTVC', () => {
+  test('output reports timing data', async ({page}) => {
+    await page.goto(`/test/output1?delay=${PAGELOAD_DELAY}`, {
+      waitUntil: 'networkidle',
+    });
+
+    const entries = await getEntries(page);
+
+    expect(entries.length).toBe(1);
+    expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY + IMAGE_DELAY);
+    expect(entries[0].duration).toBeLessThanOrEqual(PAGELOAD_DELAY + IMAGE_DELAY + FUDGE);
+    expect(entries[0].start).toBeDefined();
+    expect(entries[0].end).toBeDefined();
+  });
+
+  test('output includes detail', async ({page}) => {
+    await page.goto(`/test/output1?delay=${PAGELOAD_DELAY}`, {
+      waitUntil: 'networkidle',
+    });
+
+    const entries = await getEntries(page);
+
+    expect(entries.length).toBe(1);
+    expect(entries[0].detail).toBeDefined();
+    expect(entries[0].detail.didNetworkTimeOut).toBe(false);
+    expect(entries[0].detail.lastImageLoadTarget).toBeDefined();
+    expect(entries[0].detail.lastImageLoadTimestamp).toBeDefined();
+    expect(entries[0].detail.lastMutation).toBeDefined();
+  });
+});

--- a/test/e2e/output1/index.spec.ts
+++ b/test/e2e/output1/index.spec.ts
@@ -32,7 +32,7 @@ test.describe('TTVC', () => {
     expect(entries[0].detail).toBeDefined();
     expect(entries[0].detail.didNetworkTimeOut).toBe(false);
     const isImageElement = await page.evaluate(() => {
-      return window.entries[0].detail.lastVisualUpdate instanceof HTMLImageElement;
+      return window.entries[0].detail.lastVisibleChange instanceof HTMLImageElement;
     });
     expect(isImageElement).toBe(true);
   });

--- a/test/e2e/output2/index.html
+++ b/test/e2e/output2/index.html
@@ -1,0 +1,8 @@
+<head>
+  <script src="/dist/index.min.js"></script>
+  <script src="/analytics.js"></script>
+</head>
+
+<body>
+  <h1 id="h1">Hello world!</h1>
+</body>

--- a/test/e2e/output2/index.spec.ts
+++ b/test/e2e/output2/index.spec.ts
@@ -32,7 +32,7 @@ test.describe('TTVC', () => {
     expect(entries[0].detail.didNetworkTimeOut).toBe(false);
 
     const isMutationRecord = await page.evaluate(() => {
-      return window.entries[0].detail.lastVisualUpdate instanceof MutationRecord;
+      return window.entries[0].detail.lastVisibleChange instanceof MutationRecord;
     });
     expect(isMutationRecord).toBe(true);
   });

--- a/test/e2e/output2/index.spec.ts
+++ b/test/e2e/output2/index.spec.ts
@@ -4,25 +4,24 @@ import {FUDGE} from '../../util/constants';
 import {getEntries} from '../../util/entries';
 
 const PAGELOAD_DELAY = 200;
-const IMAGE_DELAY = 500;
 
 test.describe('TTVC', () => {
   test('output reports timing data', async ({page}) => {
-    await page.goto(`/test/output1?delay=${PAGELOAD_DELAY}`, {
+    await page.goto(`/test/output2?delay=${PAGELOAD_DELAY}`, {
       waitUntil: 'networkidle',
     });
 
     const entries = await getEntries(page);
 
     expect(entries.length).toBe(1);
-    expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY + IMAGE_DELAY);
-    expect(entries[0].duration).toBeLessThanOrEqual(PAGELOAD_DELAY + IMAGE_DELAY + FUDGE);
+    expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY);
+    expect(entries[0].duration).toBeLessThanOrEqual(PAGELOAD_DELAY + FUDGE);
     expect(entries[0].start).toBeDefined();
     expect(entries[0].end).toBeDefined();
   });
 
   test('output includes detail', async ({page}) => {
-    await page.goto(`/test/output1?delay=${PAGELOAD_DELAY}`, {
+    await page.goto(`/test/output2?delay=${PAGELOAD_DELAY}`, {
       waitUntil: 'networkidle',
     });
 
@@ -31,9 +30,10 @@ test.describe('TTVC', () => {
     expect(entries.length).toBe(1);
     expect(entries[0].detail).toBeDefined();
     expect(entries[0].detail.didNetworkTimeOut).toBe(false);
-    const isImageElement = await page.evaluate(() => {
-      return window.entries[0].detail.lastVisualUpdate instanceof HTMLImageElement;
+
+    const isMutationRecord = await page.evaluate(() => {
+      return window.entries[0].detail.lastVisualUpdate instanceof MutationRecord;
     });
-    expect(isImageElement).toBe(true);
+    expect(isMutationRecord).toBe(true);
   });
 });


### PR DESCRIPTION
Capture the last mutation and last image load data in the `detail` object reported by TTVC.  These can be useful to report to assist diagnosing regressions in the field.

![image](https://user-images.githubusercontent.com/11449340/184245664-0fbbfd12-ccfe-4787-b277-bbc1b3872b6f.png)
