### PR TITLE
Add cancel() function to public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,16 @@ The callback function may be called more than once if in-page navigation occurs.
 
 `getTTVC` may be called more than once to register more than one subscriber.
 
+#### `cancel()`
+
+```typescript
+type cancel = () => void;
+```
+
+Abort the current TTVC measurement.
+
+This method is provided as an escape hatch. Consider using `cancel` to notify @dropbox/ttvc that a user interaction has occurred and continuing the measurement may produce an invalid result.
+
 #### `incrementAjaxCount() & decrementAjaxCount()`
 
 ```typescript

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,15 @@ export const getTTVC = (callback: MetricSubscriber) => calculator?.getTTVC(callb
 export const start = () => calculator?.start(performance.now());
 
 /**
+ * Abort the current TTVC measurement.
+ *
+ * This method is provided as an escape hatch. Consider using it to notify
+ * @dropbox/ttvc that a user interaction has occurred and continuing the
+ * measurement may produce an invalid result.
+ */
+export const cancel = () => calculator?.cancel();
+
+/**
  * Call this to notify ttvc that an AJAX request has just begun.
  *
  * Instrument your site's AJAX requests with `incrementAjaxCount` and


### PR DESCRIPTION
This is the simplest version of this feature.  I'm open to adding some cancellation reasons & logging, but I couldn't come up with an obvious solution for how to report those results back.

The [web-vitals](https://github.com/GoogleChrome/web-vitals) project doesn't appear to have any patterns we can lean on for that capability either.