### PR TITLE
Instrument back/forward cache navigations

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,12 @@ export type Metric = {
     lastVisibleChange?: HTMLElement | TimestampedMutationRecord;
 
     // describes how the navigation being measured was initiated
-    navigationType: // Navigation started by clicking a link, entering the URL in the browser's address bar or form submission.
+    // NOTE: this extends the navigation type values defined in the W3 spec;
+    // "script" is usually reported as "navigation" by the browser, but we
+    // report that distinctly
+    // @see https://developer.mozilla.org/en-US/docs/Web/API/PerformanceNavigationTiming/type
+    navigationType: // Navigation started by clicking a link, by entering the
+    // URL in the browser's address bar, or by form submission.
     | 'navigate'
       // Navigation is through the browser's reload operation.
       | 'reload'
@@ -201,7 +206,7 @@ export type Metric = {
       | 'back_forward'
       // Navigation is initiated by a prerender hint.
       | 'prerender'
-      // Navigation was triggered with a script operation, e.g. in a single page application.
+      // Navigation is triggered with a script operation, e.g. in a single page application.
       | 'script';
   };
 };

--- a/README.md
+++ b/README.md
@@ -191,6 +191,18 @@ export type Metric = {
     // (this can be either a mutation or a load event target, whichever
     // occurred last)
     lastVisibleChange?: HTMLElement | TimestampedMutationRecord;
+
+    // describes how the navigation being measured was initiated
+    navigationType: // Navigation started by clicking a link, entering the URL in the browser's address bar or form submission.
+    | 'navigate'
+      // Navigation is through the browser's reload operation.
+      | 'reload'
+      // Navigation is through the browser's history traversal operation.
+      | 'back_forward'
+      // Navigation is initiated by a prerender hint.
+      | 'prerender'
+      // Navigation was triggered with a script operation, e.g. in a single page application.
+      | 'script';
   };
 };
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,16 @@ export const init = (options?: TtvcOptions) => {
 
   calculator = getVisuallyCompleteCalculator();
   void calculator.start();
-  window.addEventListener('locationchange', () => void calculator.start(performance.now()));
+
+  // restart measurement for SPA navigation
+  window.addEventListener('locationchange', (event) => void calculator.start(event.timeStamp));
+
+  // restart measurement on back/forward cache page restoration
+  window.addEventListener('pageshow', (event) => {
+    // abort if this is the initial pageload
+    if (!event.persisted) return;
+    void calculator.start(event.timeStamp);
+  });
 };
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ export const init = (options?: TtvcOptions) => {
   window.addEventListener('pageshow', (event) => {
     // abort if this is the initial pageload
     if (!event.persisted) return;
-    void calculator.start(event.timeStamp);
+    void calculator.start(event.timeStamp, true);
   });
 };
 

--- a/src/visuallyCompleteCalculator.ts
+++ b/src/visuallyCompleteCalculator.ts
@@ -5,14 +5,7 @@ import {InViewportImageObserver} from './inViewportImageObserver';
 import {Logger} from './util/logger';
 
 export type NavigationType =
-  // Navigation started by clicking a link, entering the URL in the browser's address bar or form submission.
-  | 'navigate'
-  // Navigation is through the browser's reload operation.
-  | 'reload'
-  // Navigation is through the browser's history traversal operation.
-  | 'back_forward'
-  // Navigation is initiated by a prerender hint.
-  | 'prerender'
+  | NavigationTimingType
   // Navigation was triggered with a script operation, e.g. in a single page application.
   | 'script';
 

--- a/test/e2e/bfcache/about.html
+++ b/test/e2e/bfcache/about.html
@@ -1,0 +1,13 @@
+<head>
+  <script src="/dist/index.min.js"></script>
+  <script src="/analytics.js"></script>
+  <script>
+    window.addEventListener('pageshow', (event) => {
+      if (event.persisted) TTVC.start();
+    });
+  </script>
+</head>
+
+<body>
+  <h1 id="h1">About</h1>
+</body>

--- a/test/e2e/bfcache/about.html
+++ b/test/e2e/bfcache/about.html
@@ -1,11 +1,6 @@
 <head>
   <script src="/dist/index.min.js"></script>
   <script src="/analytics.js"></script>
-  <script>
-    window.addEventListener('pageshow', (event) => {
-      if (event.persisted) TTVC.start();
-    });
-  </script>
 </head>
 
 <body>

--- a/test/e2e/bfcache/index.html
+++ b/test/e2e/bfcache/index.html
@@ -1,11 +1,6 @@
 <head>
   <script src="/dist/index.min.js"></script>
   <script src="/analytics.js"></script>
-  <script>
-    window.addEventListener('pageshow', (event) => {
-      if (event.persisted) TTVC.start();
-    });
-  </script>
 </head>
 
 <body>

--- a/test/e2e/bfcache/index.html
+++ b/test/e2e/bfcache/index.html
@@ -1,0 +1,13 @@
+<head>
+  <script src="/dist/index.min.js"></script>
+  <script src="/analytics.js"></script>
+  <script>
+    window.addEventListener('pageshow', (event) => {
+      if (event.persisted) TTVC.start();
+    });
+  </script>
+</head>
+
+<body>
+  <h1 id="h1">Hello world!</h1>
+</body>

--- a/test/e2e/bfcache/index.spec.ts
+++ b/test/e2e/bfcache/index.spec.ts
@@ -1,0 +1,38 @@
+import {test, expect} from '@playwright/test';
+
+import {FUDGE} from '../../util/constants';
+import {getEntries} from '../../util/entries';
+
+const PAGELOAD_DELAY = 1000;
+
+test.describe('TTVC', () => {
+  test('a static HTML document', async ({page}) => {
+    await page.goto(`/test/bfcache?delay=${PAGELOAD_DELAY}&cache=true`, {
+      waitUntil: 'networkidle',
+    });
+
+    let entries = await getEntries(page);
+
+    expect(entries.length).toBe(1);
+    expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY);
+    expect(entries[0].duration).toBeLessThanOrEqual(PAGELOAD_DELAY + FUDGE);
+
+    await page.goto(`/test/bfcache/about?delay=${PAGELOAD_DELAY}&cache=true`, {
+      waitUntil: 'networkidle',
+    });
+
+    entries = await getEntries(page);
+
+    expect(entries.length).toBe(1);
+    expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY);
+    expect(entries[0].duration).toBeLessThanOrEqual(PAGELOAD_DELAY + FUDGE);
+
+    await page.goBack({waitUntil: 'networkidle'});
+
+    entries = await getEntries(page);
+
+    // note: webkit clears previous values from this list on page restore
+    expect(entries[entries.length - 1].duration).toBeGreaterThanOrEqual(0);
+    expect(entries[entries.length - 1].duration).toBeLessThanOrEqual(FUDGE);
+  });
+});

--- a/test/e2e/bfcache/index.spec.ts
+++ b/test/e2e/bfcache/index.spec.ts
@@ -16,6 +16,7 @@ test.describe('TTVC', () => {
     expect(entries.length).toBe(1);
     expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY);
     expect(entries[0].duration).toBeLessThanOrEqual(PAGELOAD_DELAY + FUDGE);
+    expect(entries[0].detail.navigationType).toBe('navigate');
 
     await page.goto(`/test/bfcache/about?delay=${PAGELOAD_DELAY}&cache=true`, {
       waitUntil: 'networkidle',
@@ -26,6 +27,7 @@ test.describe('TTVC', () => {
     expect(entries.length).toBe(1);
     expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY);
     expect(entries[0].duration).toBeLessThanOrEqual(PAGELOAD_DELAY + FUDGE);
+    expect(entries[0].detail.navigationType).toBe('navigate');
 
     await page.goBack({waitUntil: 'networkidle'});
 
@@ -34,5 +36,6 @@ test.describe('TTVC', () => {
     // note: webkit clears previous values from this list on page restore
     expect(entries[entries.length - 1].duration).toBeGreaterThanOrEqual(0);
     expect(entries[entries.length - 1].duration).toBeLessThanOrEqual(FUDGE);
+    expect(entries[entries.length - 1].detail.navigationType).toBe('back_forward');
   });
 });

--- a/test/server/server.mjs
+++ b/test/server/server.mjs
@@ -10,8 +10,8 @@ const app = express();
 // disable browser cache
 app.use(({query}, res, next) => {
   if (!query?.cache) {
-  res.header('Cache-Control', 'no-cache');
-  res.header('Vary', '*'); // macOS safari doesn't respect Cache-Control
+    res.header('Cache-Control', 'no-cache');
+    res.header('Vary', '*'); // macOS safari doesn't respect Cache-Control
   }
   next();
 });
@@ -49,9 +49,10 @@ app.post('/api', (req, res) => {
   res.json(req.body);
 });
 
-app.get('/test/:view', ({params}, res) => {
+app.get('/test/:view/:route?', ({params}, res) => {
   const view = params.view;
-  res.sendFile(`test/e2e/${view}/index.html`, {root: '.'});
+  const route = params.route ?? 'index';
+  res.sendFile(`test/e2e/${view}/${route}.html`, {root: '.'});
 });
 
 app.listen(PORT, () => {

--- a/test/server/server.mjs
+++ b/test/server/server.mjs
@@ -8,9 +8,11 @@ const PORT = process.env.PORT ?? 3000;
 const app = express();
 
 // disable browser cache
-app.use((req, res, next) => {
+app.use(({query}, res, next) => {
+  if (!query?.cache) {
   res.header('Cache-Control', 'no-cache');
   res.header('Vary', '*'); // macOS safari doesn't respect Cache-Control
+  }
   next();
 });
 


### PR DESCRIPTION
This change builds instrumentation for navigations enhanced by browser back/forward caches into the library.

This uses the `pageshow` event and it's `.persisted` property to identify a navigation and trigger a new measurement.

NOTE: This change bakes into the library that we should start a new measurement for TTVC whenever a page is restored from the back/forward cache.  I _think_ this is almost always desirable, and therefore a good default, but I am not certain.

It's possible for a user to accomplish this today in user space, by importing the `start()` method and calling it manually.  It would also be possible to make this an opt-out configuration property.

~~I think a related question is how or whether we should let the user know that the measurement was started via back/forward cache restore.~~

Edit: I pushed another commit which reports navigationType in the detail object for each metric result.  I think this addresses most of my own concerns.  If someone wants to exclude back/forward measurements, they can do so by dropping values reported with the matching navigationType.  Similarly, they can include that metadata as a tag when persisting that measurement anywhere.