### PR TITLE
Fix broken github badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 ![version](https://img.shields.io/npm/v/@dropbox/ttvc)
 ![minzip size](https://img.shields.io/bundlephobia/minzip/@dropbox/ttvc)
 
-![lint](https://img.shields.io/github/workflow/status/dropbox/ttvc/Lint/main?label=lint)
-![unit](https://img.shields.io/github/workflow/status/dropbox/ttvc/Unit%20Tests/main?label=unit)
-![playwright](https://img.shields.io/github/workflow/status/dropbox/ttvc/Playwright%20Tests/main?label=playwright)
+![lint](https://img.shields.io/github/actions/workflow/status/dropbox/ttvc/lint.yml?branch=main&label=lint)
+![unit](https://img.shields.io/github/actions/workflow/status/dropbox/ttvc/unit.yml?branch=main&label=unit)
+![playwright](https://img.shields.io/github/actions/workflow/status/dropbox/ttvc/playwright.yml?branch=main&label=playwright)
 
 - [Overview](#overview)
 - [Get started](#get-started)


### PR DESCRIPTION
It seems like GitHub changed the URL format expected for these badges.

https://github.com/badges/shields/issues/8671

Before: https://github.com/dropbox/ttvc/blob/97b5942336f4a69fd8b5f14652efd3177cce03da/README.md

After: https://github.com/dropbox/ttvc/blob/6f11af9cd7bfd41d2c7b3403e3119de396c884e3/README.md