### PR TITLE
Improve handling around performance navigation entry

### DIFF
--- a/src/.eslintrc.yaml
+++ b/src/.eslintrc.yaml
@@ -1,4 +1,2 @@
 env:
   browser: true
-rules:
-  '@typescript-eslint/ban-ts-comment': 'off'

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,6 @@ export const init = (options?: TtvcOptions) => {
   });
 
   // restart measurement when a prerendered page is navigated to
-  //@ts-ignore prerendering is an experimental feature
   if (document.prerendering) {
     window.addEventListener(
       'prerenderingchange',

--- a/src/navigationEntry.ts
+++ b/src/navigationEntry.ts
@@ -1,0 +1,15 @@
+// http://developer.mozilla.org/en-US/docs/Web/API/PerformanceNavigation/type
+const getDeprecatedNavigationType = (): NavigationTimingType => {
+  const type = window.performance.navigation.type;
+  return type === 2 ? 'back_forward' : type === 1 ? 'reload' : 'navigate';
+};
+
+export const getNavigationType = (): NavigationTimingType => {
+  return (
+    window.performance.getEntriesByType('navigation')[0]?.type || getDeprecatedNavigationType()
+  );
+};
+
+export const getActivationStart = (): number => {
+  return window.performance.getEntriesByType('navigation')[0]?.activationStart || 0;
+};

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1,0 +1,24 @@
+// Need to have at least one export or import to make this a module
+export {};
+
+// Extend built-in global types
+
+interface PerformanceEntryMap {
+  navigation: PerformanceNavigationTiming;
+}
+
+declare global {
+  interface Document {
+    // https://wicg.github.io/nav-speculation/prerendering.html#document-prerendering
+    prerendering?: boolean;
+  }
+
+  interface Performance {
+    getEntriesByType<K extends keyof PerformanceEntryMap>(type: K): PerformanceEntryMap[K][];
+  }
+
+  // https://wicg.github.io/nav-speculation/prerendering.html#performance-navigation-timing-extension
+  interface PerformanceNavigationTiming {
+    activationStart?: number;
+  }
+}

--- a/src/visuallyCompleteCalculator.ts
+++ b/src/visuallyCompleteCalculator.ts
@@ -3,6 +3,7 @@ import {waitForPageLoad} from './util';
 import {requestAllIdleCallback} from './requestAllIdleCallback';
 import {InViewportImageObserver} from './inViewportImageObserver';
 import {Logger} from './util/logger';
+import {getActivationStart, getNavigationType} from './navigationEntry';
 
 export type NavigationType =
   | NavigationTimingType
@@ -100,10 +101,7 @@ class VisuallyCompleteCalculator {
     this.activeMeasurementIndex = navigationIndex;
     Logger.info('VisuallyCompleteCalculator.start()', '::', 'index =', navigationIndex);
 
-    const activationStart: number =
-      // @ts-ignore
-      (performance?.getEntriesByType?.('navigation')[0]?.activationStart as number) || 0;
-
+    const activationStart = getActivationStart();
     if (activationStart > start) {
       start = activationStart;
     }
@@ -136,14 +134,11 @@ class VisuallyCompleteCalculator {
       // identify timestamp of last visible change
       const end = Math.max(start, this.lastImageLoadTimestamp, this.lastMutation?.timestamp ?? 0);
 
-      const navigationEntries = performance.getEntriesByType(
-        'navigation'
-      ) as PerformanceNavigationTiming[];
       const navigationType = isBfCacheRestore
         ? 'back_forward'
         : start !== 0
         ? 'script'
-        : navigationEntries[navigationEntries.length - 1].type;
+        : getNavigationType();
 
       // report result to subscribers
       this.next({

--- a/test/e2e/spa1/index.spec.ts
+++ b/test/e2e/spa1/index.spec.ts
@@ -19,6 +19,7 @@ test.describe('TTVC', () => {
       expect(entries.length).toBe(1);
       expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY);
       expect(entries[0].duration).toBeLessThanOrEqual(PAGELOAD_DELAY + FUDGE);
+      expect(entries[0].detail.navigationType).toBe('navigate');
     });
 
     test('SPA navigation', async ({page}) => {
@@ -30,6 +31,7 @@ test.describe('TTVC', () => {
 
       expect(entries[1].duration).toBeGreaterThanOrEqual(0);
       expect(entries[1].duration).toBeLessThanOrEqual(0 + FUDGE);
+      expect(entries[1].detail.navigationType).toBe('script');
     });
   });
 });

--- a/test/e2e/spa2/index.spec.ts
+++ b/test/e2e/spa2/index.spec.ts
@@ -20,6 +20,7 @@ test.describe('TTVC', () => {
       expect(entries.length).toBe(1);
       expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY + AJAX_DELAY);
       expect(entries[0].duration).toBeLessThanOrEqual(PAGELOAD_DELAY + AJAX_DELAY + FUDGE);
+      expect(entries[0].detail.navigationType).toBe('navigate');
     });
 
     test('SPA navigation', async ({page}) => {
@@ -31,6 +32,7 @@ test.describe('TTVC', () => {
 
       expect(entries[1].duration).toBeGreaterThanOrEqual(AJAX_DELAY);
       expect(entries[1].duration).toBeLessThanOrEqual(AJAX_DELAY + FUDGE);
+      expect(entries[1].detail.navigationType).toBe('script');
     });
 
     test('two overlapping SPA navigations', async ({page, browserName}) => {
@@ -55,6 +57,7 @@ test.describe('TTVC', () => {
       expect(entries.length).toBe(2);
       expect(entries[1].duration).toBeGreaterThanOrEqual(AJAX_DELAY);
       expect(entries[1].duration).toBeLessThanOrEqual(AJAX_DELAY + FUDGE);
+      expect(entries[1].detail.navigationType).toBe('script');
     });
   });
 });

--- a/test/e2e/spa3/index.spec.ts
+++ b/test/e2e/spa3/index.spec.ts
@@ -19,6 +19,7 @@ test.describe('TTVC', () => {
       expect(entries.length).toBe(1);
       expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY);
       expect(entries[0].duration).toBeLessThanOrEqual(PAGELOAD_DELAY + FUDGE);
+      expect(entries[0].detail.navigationType).toBe('navigate');
     });
 
     test('SPA navigation', async ({page}) => {
@@ -36,6 +37,7 @@ test.describe('TTVC', () => {
       expect(entries.length).toBe(2);
       expect(entries[1].duration).toBeGreaterThanOrEqual(0);
       expect(entries[1].duration).toBeLessThanOrEqual(0 + FUDGE);
+      expect(entries[1].detail.navigationType).toBe('script');
     });
   });
 });

--- a/test/e2e/spa4/index.spec.ts
+++ b/test/e2e/spa4/index.spec.ts
@@ -19,6 +19,7 @@ test.describe('TTVC', () => {
       expect(entries.length).toBe(1);
       expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY);
       expect(entries[0].duration).toBeLessThanOrEqual(PAGELOAD_DELAY + FUDGE);
+      expect(entries[0].detail.navigationType).toBe('navigate');
     });
 
     test('SPA navigation', async ({page}) => {
@@ -29,6 +30,7 @@ test.describe('TTVC', () => {
       const entries = await getEntries(page);
 
       expect(entries[1].duration).toBe(0);
+      expect(entries[1].detail.navigationType).toBe('script');
     });
   });
 });

--- a/test/e2e/spa5/index.spec.ts
+++ b/test/e2e/spa5/index.spec.ts
@@ -19,6 +19,7 @@ test.describe('TTVC', () => {
       expect(entries.length).toBe(1);
       expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY);
       expect(entries[0].duration).toBeLessThanOrEqual(PAGELOAD_DELAY + FUDGE);
+      expect(entries[0].detail.navigationType).toBe('navigate');
     });
 
     test('SPA navigation', async ({page}) => {
@@ -36,6 +37,7 @@ test.describe('TTVC', () => {
       expect(entries.length).toBe(2);
       expect(entries[1].duration).toBeGreaterThanOrEqual(0);
       expect(entries[1].duration).toBeLessThanOrEqual(0 + FUDGE);
+      expect(entries[1].detail.navigationType).toBe('script');
     });
   });
 });


### PR DESCRIPTION
Older browsers do not have support for PerformanceNavigationTiming. This changes adds fallback for getting navigation type from the deprecated `window.performance.navigation.type` when PerformanceNavigationTiming is not available.

Since `activationStart` is also on PerformanceNavigationTiming, we move this into a helper in the same file as well.

Finally, we can override the built-in browser declarations to get better typing for `getEntriesByType`, `activationStart`, and `document.prerendering`. This allows us to remove the override for `@typescript-eslint/ban-ts-comment` eslint rule since the default is pretty reasonable (`ts-expect-error` is allowed with description) https://typescript-eslint.io/rules/ban-ts-comment/


