### PR TITLE
Soft navigation on a prerendered page should still have `script` navigation type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,14 @@ export type {Metric, MetricSubscriber} from './visuallyCompleteCalculator';
 
 let calculator: VisuallyCompleteCalculator;
 
+const whenActivated = (callback: () => void) => {
+  if (document.prerendering) {
+    window.addEventListener('prerenderingchange', callback, true);
+  } else {
+    callback();
+  }
+};
+
 /**
  *  Start ttvc and begin monitoring network activity and visual changes.
  */
@@ -22,26 +30,19 @@ export const init = (options?: TtvcOptions) => {
   Logger.info('init()');
 
   calculator = getVisuallyCompleteCalculator();
-  void calculator.start();
+  whenActivated(() => {
+    void calculator.start();
 
-  // restart measurement for SPA navigation
-  window.addEventListener('locationchange', (event) => void calculator.start(event.timeStamp));
+    // restart measurement for SPA navigation
+    window.addEventListener('locationchange', (event) => void calculator.start(event.timeStamp));
 
-  // restart measurement on back/forward cache page restoration
-  window.addEventListener('pageshow', (event) => {
-    // abort if this is the initial pageload
-    if (!event.persisted) return;
-    void calculator.start(event.timeStamp, true);
+    // restart measurement on back/forward cache page restoration
+    window.addEventListener('pageshow', (event) => {
+      // abort if this is the initial pageload
+      if (!event.persisted) return;
+      void calculator.start(event.timeStamp, true);
+    });
   });
-
-  // restart measurement when a prerendered page is navigated to
-  if (document.prerendering) {
-    window.addEventListener(
-      'prerenderingchange',
-      (event) => void calculator.start(event.timeStamp),
-      true
-    );
-  }
 };
 
 /**

--- a/src/visuallyCompleteCalculator.ts
+++ b/src/visuallyCompleteCalculator.ts
@@ -101,9 +101,16 @@ class VisuallyCompleteCalculator {
     this.activeMeasurementIndex = navigationIndex;
     Logger.info('VisuallyCompleteCalculator.start()', '::', 'index =', navigationIndex);
 
+    let navigationType: NavigationType = isBfCacheRestore
+      ? 'back_forward'
+      : start > 0
+      ? 'script'
+      : getNavigationType();
+
     const activationStart = getActivationStart();
     if (activationStart > start) {
       start = activationStart;
+      navigationType = 'prerender';
     }
 
     // setup
@@ -133,14 +140,6 @@ class VisuallyCompleteCalculator {
     if (navigationIndex === this.activeMeasurementIndex) {
       // identify timestamp of last visible change
       const end = Math.max(start, this.lastImageLoadTimestamp, this.lastMutation?.timestamp ?? 0);
-
-      const navigationType = isBfCacheRestore
-        ? 'back_forward'
-        : activationStart > 0
-        ? 'prerender'
-        : start > 0
-        ? 'script'
-        : getNavigationType();
 
       // report result to subscribers
       this.next({

--- a/test/e2e/prerender1/index2.html
+++ b/test/e2e/prerender1/index2.html
@@ -10,5 +10,32 @@
   </head>
   <body>
     <h3>Index 2 HTML</h3>
+    <ul id="nav">
+      <li><a data-goto="/home" href="#">Home</a></li>
+      <li><a data-goto="/about" href="#">About</a></li>
+    </ul>
+
+    <script type="module">
+      import {createHashHistory} from '/node_modules/history/history.production.min.js';
+      const history = createHashHistory();
+
+      // set initial path to /home
+      history.push('/home');
+
+      // set up link click handlers
+      const anchors = document.querySelectorAll('a');
+      anchors.forEach((anchor) => {
+        const url = anchor.dataset.goto;
+        anchor.addEventListener('click', (event) => {
+          event.preventDefault(0);
+          history.push(url);
+        });
+      });
+
+      // handle navigation
+      history.listen(() => {
+        document.documentElement.dispatchEvent(new Event('locationchange', {bubbles: true}));
+      });
+    </script>
   </body>
 </html>


### PR DESCRIPTION
This change fixes two issues with the prerender support:
* Soft navigation on a prerendered page should still have `script` navigation type
* Instead of restarting measuring on `prerenderingchange`, we wait for it to init if the document is currently prerendering. This method is described in https://developer.chrome.com/blog/prerender-pages/#impact-on-analytics

Since we are comparing `start` with `activationStart`, restarting measurement doesn't make sense since that would cause `start` to always be slightly after `activationStart` and therefore cause the initial navigation to a prerendered page to be classified as a soft navigation. Waiting for activation and not restarting measurement works better.

This also adds a new test case to the existing prerender tests to perform a soft navigation after landing on a prerendered page.
Due to the linked issue with Playwright, I manually performed the test case after starting the test server with `yarn run express`.
