### PR TITLE
Adding cancellation reason diagnostics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,9 @@ lib
 # VS Code settings
 .vscode
 
+# IntelliJ Settings
+.idea
+
 # Playwright
 test-results/
 playwright-report/

--- a/README.md
+++ b/README.md
@@ -243,10 +243,9 @@ export type Metric = {
 ```typescript
 export type CancellationError = {
   // time since timeOrigin that the navigation was triggered
-  // (this will be 0 for the initial pageload)
   start: number;
 
-  // time since timeOrigin that a cancellation event occurred
+  // time since timeOrigin that cancellation occurred
   end: number;
 
   // reason for cancellation
@@ -258,9 +257,10 @@ export type CancellationError = {
   // Optional target of event that triggered cancellation
   eventTarget?: EventTarget;
 
-  detail: {
-    // ... identical to `detail` property of Metric type ...
-  };
+  // the most recent visual update; this can be either a mutation or a load event target
+  lastVisibleChange?: HTMLElement | TimestampedMutationRecord;
+
+  navigationType: NavigationType;
 };
 
 export enum CancellationReason {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,12 +3,18 @@ import {TtvcOptions, setConfig} from './util/constants';
 import {Logger} from './util/logger';
 import {
   getVisuallyCompleteCalculator,
-  MetricSubscriber,
+  MetricSuccessSubscriber,
+  MetricErrorSubscriber,
   VisuallyCompleteCalculator,
 } from './visuallyCompleteCalculator.js';
 
 export type {TtvcOptions};
-export type {Metric, MetricSubscriber} from './visuallyCompleteCalculator';
+export type {
+  Metric,
+  CancellationError,
+  MetricSuccessSubscriber,
+  MetricErrorSubscriber,
+} from './visuallyCompleteCalculator';
 
 let calculator: VisuallyCompleteCalculator;
 
@@ -53,10 +59,14 @@ export const init = (options?: TtvcOptions) => {
  * @example
  * const unsubscribe = onTTVC(ms => console.log(ms));
  *
- * @param callback Triggered once for each navigation instance.
+ * @param successCallback Triggered once for each navigation instance when TTVC was successfully captured.
+ * @param [errorCallback] Triggered when TTVC failed to capture
  * @returns A function that unsubscribes the callback from this metric.
  */
-export const onTTVC = (callback: MetricSubscriber) => calculator?.onTTVC(callback);
+export const onTTVC = (
+  successCallback: MetricSuccessSubscriber,
+  errorCallback?: MetricErrorSubscriber
+) => calculator?.onTTVC(successCallback, errorCallback);
 
 /**
  * Begin measuring a new navigation.

--- a/test/e2e/interaction1/index.spec.ts
+++ b/test/e2e/interaction1/index.spec.ts
@@ -1,6 +1,6 @@
 import {test, expect} from '@playwright/test';
 
-import {entryCountIs, getEntries} from '../../util/entries';
+import {entryCountIs, getEntriesAndErrors} from '../../util/entries';
 
 const MUTATION_DELAY = 500;
 
@@ -13,15 +13,19 @@ test.describe('TTVC', () => {
     // user interaction should abort calculation
     await page.click('body', {delay: MUTATION_DELAY / 2});
 
+    // assert that no metric has been reported
+    const {entries, errors} = await getEntriesAndErrors(page);
+    expect(entries.length).toBe(0);
+
+    expect(errors.length).toBe(1);
+    expect(errors[0].cancellationReason).toBe('USER_INTERACTION');
+    expect(errors[0].eventType).toBe('click');
+
     // wait long enough to ensure ttvc would have been logged
     try {
       await entryCountIs(page, 1, 3000);
     } catch (e) {
       // pass
     }
-
-    // assert that no metric has been reported
-    const entries = await getEntries(page);
-    expect(entries.length).toBe(0);
   });
 });

--- a/test/e2e/interaction2/index.spec.ts
+++ b/test/e2e/interaction2/index.spec.ts
@@ -1,6 +1,6 @@
 import {test, expect} from '@playwright/test';
 
-import {entryCountIs, getEntries} from '../../util/entries';
+import {entryCountIs, getEntriesAndErrors} from '../../util/entries';
 
 test.describe('TTVC', () => {
   test('tab is backgrounded before page completes loading', async ({page}) => {
@@ -18,15 +18,19 @@ test.describe('TTVC', () => {
       document.dispatchEvent(new Event('visibilitychange', {bubbles: true}));
     });
 
+    // assert that no metric has been reported
+    const {entries, errors} = await getEntriesAndErrors(page);
+    expect(entries.length).toBe(0);
+
+    expect(errors.length).toBe(1);
+    expect(errors[0].cancellationReason).toBe('VISIBILITY_CHANGE');
+    expect(errors[0].eventType).toBe('visibilitychange');
+
     // wait long enough to ensure ttvc would have been logged
     try {
       await entryCountIs(page, 1, 3000);
     } catch (e) {
       // pass
     }
-
-    // assert that no metric has been reported
-    const entries = await getEntries(page);
-    expect(entries.length).toBe(0);
   });
 });

--- a/test/e2e/interaction3/index.spec.ts
+++ b/test/e2e/interaction3/index.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {FUDGE} from '../../util/constants';
-import {getEntries, entryCountIs} from '../../util/entries';
+import {entryCountIs, getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 500;
 
@@ -15,10 +15,12 @@ test.describe('TTVC', () => {
 
     await entryCountIs(page, 1);
 
-    const entries = await getEntries(page);
+    const {entries, errors} = await getEntriesAndErrors(page);
 
     expect(entries.length).toBe(1);
     expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY);
     expect(entries[0].duration).toBeLessThanOrEqual(PAGELOAD_DELAY + FUDGE);
+
+    expect(errors.length).toBe(0);
   });
 });

--- a/test/e2e/interaction4/index.html
+++ b/test/e2e/interaction4/index.html
@@ -1,0 +1,14 @@
+<head>
+  <script src="/dist/index.min.js"></script>
+  <script src="/analytics.js"></script>
+</head>
+
+<body>
+  <h1 id="h1">Hello world!</h1>
+
+  <script async src="/mutation.js?delay=500"></script>
+  <script async src="/stub.js?delay=750"></script>
+  <script>
+    TTVC.cancel();
+  </script>
+</body>

--- a/test/e2e/interaction4/index.spec.ts
+++ b/test/e2e/interaction4/index.spec.ts
@@ -1,0 +1,27 @@
+import {test, expect} from '@playwright/test';
+
+import {getEntriesAndErrors, entryCountIs} from '../../util/entries';
+
+const PAGELOAD_DELAY = 500;
+
+test.describe('TTVC', () => {
+  test('measurement manually cancelled', async ({page}) => {
+    await page.goto(`/test/interaction4?delay=${PAGELOAD_DELAY}`, {
+      waitUntil: 'domcontentloaded',
+    });
+
+    const {entries, errors} = await getEntriesAndErrors(page);
+
+    expect(entries.length).toBe(0);
+
+    expect(errors[0].cancellationReason).toBe('MANUAL_CANCELLATION');
+    expect(errors.length).toBe(1);
+
+    // wait long enough to ensure ttvc would have been logged
+    try {
+      await entryCountIs(page, 1, 3000);
+    } catch (e) {
+      // pass
+    }
+  });
+});

--- a/test/server/public/analytics.js
+++ b/test/server/public/analytics.js
@@ -1,5 +1,6 @@
-// use window.entries to communicate between browser and test runner processes
+// use window.entries and window.errors to communicate between browser and test runner processes
 window.entries = [];
+window.errors = [];
 
 // patch window.fetch
 const oldFetch = window.fetch;
@@ -10,7 +11,13 @@ window.fetch = (...args) => {
 
 TTVC.init({debug: true, networkTimeout: window.NETWORK_TIMEOUT ?? 3000});
 
-TTVC.onTTVC((measurement) => {
-  console.log('TTVC:', measurement);
-  window.entries.push(measurement);
-});
+TTVC.onTTVC(
+  (measurement) => {
+    console.log('TTVC:SUCCESS', measurement);
+    window.entries.push(measurement);
+  },
+  (error) => {
+    console.log('TTVC:ERROR', error);
+    window.errors.push(error);
+  }
+);

--- a/test/util/entries.ts
+++ b/test/util/entries.ts
@@ -1,15 +1,25 @@
 import type {Page} from '@playwright/test';
-import type {Metric} from '../../src';
+import type {Metric, CancellationError} from '../../src';
 
 // Use window.entries to communicate between browser and test processes
 declare global {
   interface Window {
     entries: Metric[];
+    errors: CancellationError[];
   }
 }
 
 /** Get the list of performance entries that have been recorded from the browser */
 export const getEntries = (page: Page) => page.evaluate(() => window.entries);
+
+/** Get the list of performance entries and errors that have been recorded from the browser */
+export const getEntriesAndErrors = (page: Page) =>
+  page.evaluate(() => {
+    return {
+      entries: window.entries,
+      errors: window.errors,
+    };
+  });
 
 /**
  * Wait until at least {count} performance entries have been logged.


### PR DESCRIPTION
## Why
We want to log the reason why TTVC measurement was cancelled. The most accurate way would be to implement that functionality in the library itself, especially considering that we will add more diagnostic information down the line.

## What
This implements a simple interface to add listeners to diagnostic events.

## Testing
1. Good way to test this would be to build the package, launch the express server and run `interaction1` e2e test case, performing a click/keydown/tab switch while the page is still loading. Diagnostic with the reason for measurement cancellation will be logged as a warning to the console.
