### PR TITLE
Make library import safe in non-browser environments

### DIFF
--- a/src/networkIdleObservable.ts
+++ b/src/networkIdleObservable.ts
@@ -101,7 +101,7 @@ class ResourceLoadingIdleObservable {
 
   constructor() {
     // watch out for SSR
-    if (window?.MutationObserver) {
+    if (typeof window !== 'undefined' && window?.MutationObserver) {
       window.addEventListener('load', () => {
         // watch for added or updated script tags
         const o = new MutationObserver((mutations) => {


### PR DESCRIPTION
`window?.MutationObserver` raises a `ReferenceError` when `window` is not defined (e.g. in Node.js). This code path gets hit just on import. This can be problematic particularly in unit tests and SSR.

Added a `typeof` guard which should make it not raise error on import.