### PR TITLE
getNetworkIdleObservable should not be called on import

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -101,7 +101,7 @@ export const cancel = (e?: Event) => calculator?.cancel(e);
  * For the most accurate results, `decrementAjaxCount` should be called
  * **exactly once** for each `incrementAjaxCount`.
  */
-export const incrementAjaxCount = getNetworkIdleObservable().incrementAjaxCount;
+export const incrementAjaxCount = () => getNetworkIdleObservable().incrementAjaxCount();
 
 /**
  * Call this to notify ttvc that an AJAX request has just resolved.
@@ -112,4 +112,4 @@ export const incrementAjaxCount = getNetworkIdleObservable().incrementAjaxCount;
  * For the most accurate results, `decrementAjaxCount` should be called
  * **exactly once** for each `incrementAjaxCount`.
  */
-export const decrementAjaxCount = getNetworkIdleObservable().decrementAjaxCount;
+export const decrementAjaxCount = () => getNetworkIdleObservable().decrementAjaxCount();

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,9 @@ export const init = (options?: TtvcOptions) => {
 
   Logger.info('init()');
 
+  // initialize network monitoring
+  getNetworkIdleObservable();
+
   calculator = getVisuallyCompleteCalculator();
   whenActivated(() => {
     void calculator.start();


### PR DESCRIPTION
This is a follow up to #78.  This further improves the behaviour of the library by ensuring that simply importing the library will not attempt to trigger any side effects.