### PR TITLE
Logging only the first manual cancellation of the measurement

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,12 +332,14 @@ The callback function may be called more than once if in-page navigation occurs.
 #### `cancel()`
 
 ```typescript
-type cancel = () => void;
+type cancel = (eventType?: string) => void;
 ```
 
 Abort the current TTVC measurement.
 
 This method is provided as an escape hatch. Consider using `cancel` to notify @dropbox/ttvc that a user interaction has occurred and continuing the measurement may produce an invalid result.
+
+An optional argument can be passed specifying the type of event that triggered the cancellation. This will be logged to the error callback, and so is used only for diagnostics.
 
 #### `incrementAjaxCount() & decrementAjaxCount()`
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,8 +87,10 @@ export const start = () => calculator?.start(performance.now());
  * This method is provided as an escape hatch. Consider using it to notify
  * @dropbox/ttvc that a user interaction has occurred and continuing the
  * measurement may produce an invalid result.
+ *
+ * @param eventType The type of event that triggered the cancellation. This will be logged to the error callback.
  */
-export const cancel = () => calculator?.cancel();
+export const cancel = (eventType?: string) => calculator?.cancel(eventType);
 
 /**
  * Call this to notify ttvc that an AJAX request has just begun.

--- a/src/visuallyCompleteCalculator.ts
+++ b/src/visuallyCompleteCalculator.ts
@@ -137,7 +137,7 @@ class VisuallyCompleteCalculator {
 
   /**
    * expose a method to abort the current TTVC measurement
-   * @param eventType - type of event that triggered cancellation (note that cancellationReason will be set to "manual" regardless of this value).
+   * @param eventType - type of event that triggered cancellation (note that cancellationReason will be set to "MANUAL_CANCELLATION" regardless of this value).
    */
   cancel(eventType?: string) {
     Logger.info(
@@ -146,16 +146,19 @@ class VisuallyCompleteCalculator {
       'index =',
       this.activeMeasurementIndex
     );
-    this.activeMeasurementIndex = undefined;
 
-    this.error({
-      start: getActivationStart(),
-      end: performance.now(),
-      cancellationReason: CancellationReason.MANUAL_CANCELLATION,
-      eventType: eventType,
-      navigationType: getNavigationType(),
-      lastVisibleChange: this.getLastVisibleChange(),
-    });
+    if (this.activeMeasurementIndex) {
+      this.error({
+        start: getActivationStart(),
+        end: performance.now(),
+        cancellationReason: CancellationReason.MANUAL_CANCELLATION,
+        eventType: eventType,
+        navigationType: getNavigationType(),
+        lastVisibleChange: this.getLastVisibleChange(),
+      });
+    }
+
+    this.activeMeasurementIndex = undefined;
   }
 
   /** begin measuring a new navigation */

--- a/test/e2e/cancellation1/index.html
+++ b/test/e2e/cancellation1/index.html
@@ -1,0 +1,16 @@
+<head>
+  <script src="/dist/index.min.js"></script>
+  <script src="/analytics.js"></script>
+</head>
+
+<body>
+  <h1 id="h1">Hello world!</h1>
+
+  <script async src="/mutation.js?delay=500"></script>
+  <script async src="/stub.js?delay=750"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      TTVC.cancel('test_event_type');
+    });
+  </script>
+</body>

--- a/test/e2e/cancellation1/index.html
+++ b/test/e2e/cancellation1/index.html
@@ -9,7 +9,7 @@
   <script async src="/mutation.js?delay=500"></script>
   <script async src="/stub.js?delay=750"></script>
   <script>
-    document.addEventListener('DOMContentLoaded', function() {
+    document.addEventListener('DOMContentLoaded', function () {
       TTVC.cancel('test_event_type');
     });
   </script>

--- a/test/e2e/cancellation1/index.spec.ts
+++ b/test/e2e/cancellation1/index.spec.ts
@@ -1,0 +1,26 @@
+import {test, expect} from '@playwright/test';
+
+import {entryCountIs, getEntriesAndErrors} from '../../util/entries';
+
+test.describe('TTVC', () => {
+  test('manual cancellation of measurement through API', async ({page}) => {
+    await page.goto(`/test/cancellation1`, {
+      waitUntil: 'domcontentloaded',
+    });
+
+    // assert that no metric has been reported
+    const {entries, errors} = await getEntriesAndErrors(page);
+    expect(entries.length).toBe(0);
+
+    expect(errors.length).toBe(1);
+    expect(errors[0].cancellationReason).toBe('MANUAL_CANCELLATION');
+    expect(errors[0].eventType).toBe('test_event_type');
+
+    // wait long enough to ensure ttvc would have been logged
+    try {
+      await entryCountIs(page, 1, 3000);
+    } catch (e) {
+      // pass
+    }
+  });
+});

--- a/test/e2e/cancellation2/index.html
+++ b/test/e2e/cancellation2/index.html
@@ -9,7 +9,7 @@
   <script async src="/mutation.js?delay=500"></script>
   <script async src="/stub.js?delay=750"></script>
   <script>
-    document.addEventListener('DOMContentLoaded', function() {
+    document.addEventListener('DOMContentLoaded', function () {
       TTVC.cancel('test_event_type_1');
       setTimeout(() => {
         TTVC.cancel('test_event_type_2');

--- a/test/e2e/cancellation2/index.html
+++ b/test/e2e/cancellation2/index.html
@@ -1,0 +1,19 @@
+<head>
+  <script src="/dist/index.min.js"></script>
+  <script src="/analytics.js"></script>
+</head>
+
+<body>
+  <h1 id="h1">Hello world!</h1>
+
+  <script async src="/mutation.js?delay=500"></script>
+  <script async src="/stub.js?delay=750"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      TTVC.cancel('test_event_type_1');
+      setTimeout(() => {
+        TTVC.cancel('test_event_type_2');
+      }, 0);
+    });
+  </script>
+</body>

--- a/test/e2e/cancellation2/index.spec.ts
+++ b/test/e2e/cancellation2/index.spec.ts
@@ -1,0 +1,26 @@
+import {test, expect} from '@playwright/test';
+
+import {entryCountIs, getEntriesAndErrors} from '../../util/entries';
+
+test.describe('TTVC', () => {
+  test('several manual cancellations result in one error callback invocation', async ({page}) => {
+    await page.goto(`/test/cancellation2`, {
+      waitUntil: 'domcontentloaded',
+    });
+
+    // assert that no metric has been reported
+    const {entries, errors} = await getEntriesAndErrors(page);
+    expect(entries.length).toBe(0);
+
+    expect(errors.length).toBe(1);
+    expect(errors[0].cancellationReason).toBe('MANUAL_CANCELLATION');
+    expect(errors[0].eventType).toBe('test_event_type_1');
+
+    // wait long enough to ensure ttvc would have been logged
+    try {
+      await entryCountIs(page, 1, 3000);
+    } catch (e) {
+      // pass
+    }
+  });
+});


### PR DESCRIPTION
# What is this
Currently, TTVC will invoke error callback for every call of `cancel` (manual measurement cancellation). Meaning that if the measurement was manually cancelled from two different places, two errors will be reported.

This refactors the code to only invoke error callback once per manual cancellation.

Additionally, this fixes a bug where `eventType` passed to manual `cancel` method was not getting all the way through to the error callback.

# Testing
- Added two additional playwright scripts to catch regressions specifically with manual cancellations.