### PR TITLE
Consolidating e2e tests to use new getEntriesAndErrors

### DIFF
--- a/test/e2e/ajax1/index.spec.ts
+++ b/test/e2e/ajax1/index.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {FUDGE} from '../../util/constants';
-import {getEntries} from '../../util/entries';
+import {getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 200;
 const AJAX_DELAY = 500; // see text-mutation.html
@@ -13,7 +13,7 @@ test.describe('TTVC', () => {
     });
 
     // await entryCountIs(page, 1);
-    const entries = await getEntries(page);
+    const {entries} = await getEntriesAndErrors(page);
 
     expect(entries.length).toBe(1);
     expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY + AJAX_DELAY);

--- a/test/e2e/ajax2/index.spec.ts
+++ b/test/e2e/ajax2/index.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {FUDGE} from '../../util/constants';
-import {getEntries} from '../../util/entries';
+import {getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 200;
 const AJAX_DELAY = 500; // see text-mutation.html
@@ -12,7 +12,7 @@ test.describe('TTVC', () => {
       waitUntil: 'networkidle',
     });
 
-    const entries = await getEntries(page);
+    const {entries} = await getEntriesAndErrors(page);
 
     expect(entries.length).toBe(1);
     expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY + AJAX_DELAY);

--- a/test/e2e/ajax3/index.spec.ts
+++ b/test/e2e/ajax3/index.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {FUDGE} from '../../util/constants';
-import {getEntries} from '../../util/entries';
+import {getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 200;
 const AJAX_DELAY = 500; // see text-mutation.html
@@ -12,7 +12,7 @@ test.describe('TTVC', () => {
       waitUntil: 'networkidle',
     });
 
-    const entries = await getEntries(page);
+    const {entries} = await getEntriesAndErrors(page);
 
     expect(entries.length).toBe(1);
     expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY + AJAX_DELAY);

--- a/test/e2e/ajax4/index.spec.ts
+++ b/test/e2e/ajax4/index.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {FUDGE} from '../../util/constants';
-import {entryCountIs, getEntries} from '../../util/entries';
+import {entryCountIs, getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 200;
 
@@ -12,7 +12,7 @@ test.describe('TTVC', () => {
     });
 
     await entryCountIs(page, 1, 30000);
-    const entries = await getEntries(page);
+    const {entries} = await getEntriesAndErrors(page);
 
     expect(entries.length).toBe(1);
     expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY);

--- a/test/e2e/ajax5/index.spec.ts
+++ b/test/e2e/ajax5/index.spec.ts
@@ -1,6 +1,6 @@
 import {test, expect} from '@playwright/test';
 
-import {entryCountIs, getEntries} from '../../util/entries';
+import {entryCountIs, getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 200;
 
@@ -17,7 +17,7 @@ test.describe('TTVC', () => {
       // pass
     }
 
-    const entries = await getEntries(page);
+    const {entries} = await getEntriesAndErrors(page);
 
     // ttvc should never be reported
     expect(entries.length).toBe(0);

--- a/test/e2e/bfcache/index.spec.ts
+++ b/test/e2e/bfcache/index.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {FUDGE} from '../../util/constants';
-import {getEntries} from '../../util/entries';
+import {getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 1000;
 
@@ -11,7 +11,7 @@ test.describe('TTVC', () => {
       waitUntil: 'networkidle',
     });
 
-    let entries = await getEntries(page);
+    let {entries} = await getEntriesAndErrors(page);
 
     expect(entries.length).toBe(1);
     expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY);
@@ -22,7 +22,7 @@ test.describe('TTVC', () => {
       waitUntil: 'networkidle',
     });
 
-    entries = await getEntries(page);
+    ({entries} = await getEntriesAndErrors(page));
 
     expect(entries.length).toBe(1);
     expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY);
@@ -31,7 +31,7 @@ test.describe('TTVC', () => {
 
     await page.goBack({waitUntil: 'networkidle'});
 
-    entries = await getEntries(page);
+    ({entries} = await getEntriesAndErrors(page));
 
     // note: webkit clears previous values from this list on page restore
     expect(entries[entries.length - 1].duration).toBeGreaterThanOrEqual(0);

--- a/test/e2e/composition1/index.spec.ts
+++ b/test/e2e/composition1/index.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {FUDGE} from '../../util/constants';
-import {getEntries} from '../../util/entries';
+import {getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 200;
 const AJAX_DELAY = 500;
@@ -13,7 +13,7 @@ test.describe('TTVC', () => {
       waitUntil: 'networkidle',
     });
 
-    const entries = await getEntries(page);
+    const {entries} = await getEntriesAndErrors(page);
     expect(entries.length).toBe(1);
 
     const expectedTtvc = PAGELOAD_DELAY + AJAX_DELAY + SCRIPT_DELAY;

--- a/test/e2e/composition2/index.spec.ts
+++ b/test/e2e/composition2/index.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {FUDGE} from '../../util/constants';
-import {getEntries} from '../../util/entries';
+import {getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 200;
 const AJAX_DELAY = 500;
@@ -16,7 +16,7 @@ test.describe('TTVC', () => {
       waitUntil: 'networkidle',
     });
 
-    const entries = await getEntries(page);
+    const {entries} = await getEntriesAndErrors(page);
     expect(entries.length).toBe(1);
 
     const expectedTtvc = PAGELOAD_DELAY + SCRIPT_DELAY + AJAX_DELAY + CPU_DELAY + SCRIPT_DELAY;

--- a/test/e2e/composition3/index.spec.ts
+++ b/test/e2e/composition3/index.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {FUDGE} from '../../util/constants';
-import {entryCountIs, getEntries} from '../../util/entries';
+import {entryCountIs, getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 200;
 const AJAX_DELAY = 500;
@@ -15,7 +15,7 @@ test.describe('TTVC', () => {
     });
 
     await entryCountIs(page, 1);
-    const entries = await getEntries(page);
+    const {entries} = await getEntriesAndErrors(page);
     expect(entries.length).toBe(1);
 
     const expectedTtvc = PAGELOAD_DELAY + SCRIPT_DELAY + AJAX_DELAY + CPU_DELAY + SCRIPT_DELAY;

--- a/test/e2e/composition4/index.spec.ts
+++ b/test/e2e/composition4/index.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {FUDGE} from '../../util/constants';
-import {entryCountIs, getEntries} from '../../util/entries';
+import {entryCountIs, getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 200;
 const AJAX_DELAY = 500;
@@ -14,7 +14,7 @@ test.describe('TTVC', () => {
     });
 
     await entryCountIs(page, 1);
-    const entries = await getEntries(page);
+    const {entries} = await getEntriesAndErrors(page);
     expect(entries.length).toBe(1);
 
     const expectedTtvc = PAGELOAD_DELAY + AJAX_DELAY + TIMEOUT_DELAY + AJAX_DELAY;

--- a/test/e2e/cpu1/index.spec.ts
+++ b/test/e2e/cpu1/index.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {FUDGE} from '../../util/constants';
-import {entryCountIs, getEntries} from '../../util/entries';
+import {entryCountIs, getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 200;
 const CPU_DELAY = 500;
@@ -13,7 +13,7 @@ test.describe('TTVC', () => {
     });
 
     await entryCountIs(page, 1);
-    const entries = await getEntries(page);
+    const {entries} = await getEntriesAndErrors(page);
 
     expect(entries.length).toBe(1);
     expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY + CPU_DELAY);

--- a/test/e2e/error1/index.spec.ts
+++ b/test/e2e/error1/index.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {FUDGE} from '../../util/constants';
-import {getEntries} from '../../util/entries';
+import {getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 200;
 const IMAGE_DELAY = 500;
@@ -12,7 +12,7 @@ test.describe('TTVC', () => {
       waitUntil: 'networkidle',
     });
 
-    const entries = await getEntries(page);
+    const {entries} = await getEntriesAndErrors(page);
 
     expect(entries.length).toBe(1);
     expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY + IMAGE_DELAY);

--- a/test/e2e/error2/index.spec.ts
+++ b/test/e2e/error2/index.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {FUDGE} from '../../util/constants';
-import {getEntries} from '../../util/entries';
+import {getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 200;
 const IMAGE_DELAY = 500;
@@ -12,7 +12,7 @@ test.describe('TTVC', () => {
       waitUntil: 'networkidle',
     });
 
-    const entries = await getEntries(page);
+    const {entries} = await getEntriesAndErrors(page);
 
     expect(entries.length).toBe(1);
     const expectedTtvc = PAGELOAD_DELAY + IMAGE_DELAY;

--- a/test/e2e/error3/index.spec.ts
+++ b/test/e2e/error3/index.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {FUDGE} from '../../util/constants';
-import {getEntries} from '../../util/entries';
+import {getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 200;
 const SCRIPT_DELAY = 200;
@@ -14,7 +14,7 @@ test.describe('TTVC', () => {
       waitUntil: 'networkidle',
     });
 
-    const entries = await getEntries(page);
+    const {entries} = await getEntriesAndErrors(page);
 
     expect(entries.length).toBe(1);
     const expectedTtvc = PAGELOAD_DELAY + SCRIPT_DELAY;

--- a/test/e2e/error4/index.spec.ts
+++ b/test/e2e/error4/index.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {FUDGE} from '../../util/constants';
-import {getEntries} from '../../util/entries';
+import {getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 200;
 const SCRIPT_DELAY = 500;
@@ -12,7 +12,7 @@ test.describe('TTVC', () => {
       waitUntil: 'networkidle',
     });
 
-    const entries = await getEntries(page);
+    const {entries} = await getEntriesAndErrors(page);
 
     expect(entries.length).toBe(1);
     expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY + SCRIPT_DELAY);

--- a/test/e2e/error6/index.spec.ts
+++ b/test/e2e/error6/index.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {FUDGE} from '../../util/constants';
-import {getEntries} from '../../util/entries';
+import {getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 200;
 
@@ -14,7 +14,7 @@ test.describe('TTVC', () => {
       waitUntil: 'networkidle',
     });
 
-    const entries = await getEntries(page);
+    const {entries} = await getEntriesAndErrors(page);
 
     expect(errors.length).toBe(0);
 

--- a/test/e2e/iframe1/index.spec.ts
+++ b/test/e2e/iframe1/index.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {FUDGE} from '../../util/constants';
-import {getEntries} from '../../util/entries';
+import {getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 200;
 const IFRAME_DELAY = 500;
@@ -12,7 +12,7 @@ test.describe('TTVC', () => {
       waitUntil: 'networkidle',
     });
 
-    const entries = await getEntries(page);
+    const {entries} = await getEntriesAndErrors(page);
 
     expect(entries.length).toBe(1);
     expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY + IFRAME_DELAY);

--- a/test/e2e/iframe2/index.spec.ts
+++ b/test/e2e/iframe2/index.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {FUDGE} from '../../util/constants';
-import {getEntries} from '../../util/entries';
+import {getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 200;
 const IFRAME_DELAY = 500;
@@ -12,7 +12,7 @@ test.describe('TTVC', () => {
       waitUntil: 'networkidle',
     });
 
-    const entries = await getEntries(page);
+    const {entries} = await getEntriesAndErrors(page);
 
     expect(entries.length).toBe(1);
     expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY + IFRAME_DELAY);

--- a/test/e2e/iframe3/index.spec.ts
+++ b/test/e2e/iframe3/index.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {FUDGE} from '../../util/constants';
-import {getEntries} from '../../util/entries';
+import {getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 200;
 
@@ -11,7 +11,7 @@ test.describe('TTVC', () => {
       waitUntil: 'networkidle',
     });
 
-    const entries = await getEntries(page);
+    const {entries} = await getEntriesAndErrors(page);
 
     expect(entries.length).toBe(1);
     expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY);

--- a/test/e2e/images1/index.spec.ts
+++ b/test/e2e/images1/index.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {FUDGE} from '../../util/constants';
-import {getEntries} from '../../util/entries';
+import {getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 1000;
 const IMAGE_DELAY = 500;
@@ -12,7 +12,7 @@ test.describe('TTVC', () => {
       waitUntil: 'networkidle',
     });
 
-    const entries = await getEntries(page);
+    const {entries} = await getEntriesAndErrors(page);
 
     expect(entries.length).toBe(1);
     expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY + IMAGE_DELAY);

--- a/test/e2e/images2/index.spec.ts
+++ b/test/e2e/images2/index.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {FUDGE} from '../../util/constants';
-import {getEntries} from '../../util/entries';
+import {getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 1000;
 const IMAGE_DELAY = 500;
@@ -12,7 +12,7 @@ test.describe('TTVC', () => {
       waitUntil: 'networkidle',
     });
 
-    const entries = await getEntries(page);
+    const {entries} = await getEntriesAndErrors(page);
 
     expect(entries.length).toBe(1);
     expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY + IMAGE_DELAY);

--- a/test/e2e/images3/index.spec.ts
+++ b/test/e2e/images3/index.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {FUDGE} from '../../util/constants';
-import {getEntries} from '../../util/entries';
+import {getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 1000;
 const LONGEST_IMAGE_DELAY = 400;
@@ -12,7 +12,7 @@ test.describe('TTVC', () => {
       waitUntil: 'networkidle',
     });
 
-    const entries = await getEntries(page);
+    const {entries} = await getEntriesAndErrors(page);
 
     expect(entries.length).toBe(1);
     expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY + LONGEST_IMAGE_DELAY);

--- a/test/e2e/images4/index.spec.ts
+++ b/test/e2e/images4/index.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {FUDGE} from '../../util/constants';
-import {getEntries} from '../../util/entries';
+import {getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 1000;
 const LONGEST_IMAGE_DELAY = 400;
@@ -12,7 +12,7 @@ test.describe('TTVC', () => {
       waitUntil: 'networkidle',
     });
 
-    const entries = await getEntries(page);
+    const {entries} = await getEntriesAndErrors(page);
 
     expect(entries.length).toBe(1);
     expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY + LONGEST_IMAGE_DELAY);

--- a/test/e2e/images5/index.spec.ts
+++ b/test/e2e/images5/index.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {FUDGE} from '../../util/constants';
-import {getEntries} from '../../util/entries';
+import {getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 1000;
 const IMAGE_DELAY = 500;
@@ -12,7 +12,7 @@ test.describe('TTVC', () => {
       waitUntil: 'networkidle',
     });
 
-    const entries = await getEntries(page);
+    const {entries} = await getEntriesAndErrors(page);
 
     expect(entries.length).toBe(1);
     expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY + IMAGE_DELAY);

--- a/test/e2e/images6/index.spec.ts
+++ b/test/e2e/images6/index.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {FUDGE} from '../../util/constants';
-import {getEntries, entryCountIs} from '../../util/entries';
+import {getEntriesAndErrors, entryCountIs} from '../../util/entries';
 
 const PAGELOAD_DELAY = 1000;
 
@@ -13,7 +13,7 @@ test.describe('TTVC', () => {
 
     await entryCountIs(page, 1);
 
-    const entries = await getEntries(page);
+    const {entries} = await getEntriesAndErrors(page);
 
     expect(entries.length).toBe(1);
     expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY);

--- a/test/e2e/invisible1/index.spec.ts
+++ b/test/e2e/invisible1/index.spec.ts
@@ -1,6 +1,6 @@
 import {test, expect} from '@playwright/test';
 
-import {getEntries} from '../../util/entries';
+import {getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 200;
 const IMAGE_DELAY = 500;
@@ -11,7 +11,7 @@ test.describe('TTVC', () => {
       waitUntil: 'networkidle',
     });
 
-    const entries = await getEntries(page);
+    const {entries} = await getEntriesAndErrors(page);
 
     expect(entries.length).toBe(1);
     expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY);

--- a/test/e2e/invisible2/index.spec.ts
+++ b/test/e2e/invisible2/index.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {FUDGE} from '../../util/constants';
-import {getEntries} from '../../util/entries';
+import {getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 200;
 
@@ -11,7 +11,7 @@ test.describe('TTVC', () => {
       waitUntil: 'networkidle',
     });
 
-    const entries = await getEntries(page);
+    const {entries} = await getEntriesAndErrors(page);
 
     expect(entries.length).toBe(1);
     expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY);

--- a/test/e2e/invisible3/index.spec.ts
+++ b/test/e2e/invisible3/index.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {FUDGE} from '../../util/constants';
-import {getEntries} from '../../util/entries';
+import {getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 200;
 const SCRIPT_DELAY = 200;
@@ -14,7 +14,7 @@ test.describe('TTVC', () => {
       waitUntil: 'networkidle',
     });
 
-    const entries = await getEntries(page);
+    const {entries} = await getEntriesAndErrors(page);
 
     expect(entries.length).toBe(1);
     const expectedTtvc = PAGELOAD_DELAY + SCRIPT_DELAY;

--- a/test/e2e/invisible4/index.spec.ts
+++ b/test/e2e/invisible4/index.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {FUDGE} from '../../util/constants';
-import {getEntries} from '../../util/entries';
+import {getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 200;
 const SCRIPT_DELAY = 200;
@@ -12,7 +12,7 @@ test.describe('TTVC', () => {
       waitUntil: 'networkidle',
     });
 
-    const entries = await getEntries(page);
+    const {entries} = await getEntriesAndErrors(page);
 
     expect(entries.length).toBe(1);
     const expectedTtvc = PAGELOAD_DELAY + SCRIPT_DELAY;

--- a/test/e2e/invisible5/index.spec.ts
+++ b/test/e2e/invisible5/index.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {FUDGE} from '../../util/constants';
-import {getEntries} from '../../util/entries';
+import {getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 200;
 const SCRIPT_DELAY = 200;
@@ -12,7 +12,7 @@ test.describe('TTVC', () => {
       waitUntil: 'networkidle',
     });
 
-    const entries = await getEntries(page);
+    const {entries} = await getEntriesAndErrors(page);
 
     expect(entries.length).toBe(1);
     const expectedTtvc = PAGELOAD_DELAY + SCRIPT_DELAY;

--- a/test/e2e/invisible6/index.spec.ts
+++ b/test/e2e/invisible6/index.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {FUDGE} from '../../util/constants';
-import {getEntries} from '../../util/entries';
+import {getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 200;
 const SCRIPT_DELAY = 200;
@@ -12,7 +12,7 @@ test.describe('TTVC', () => {
       waitUntil: 'networkidle',
     });
 
-    const entries = await getEntries(page);
+    const {entries} = await getEntriesAndErrors(page);
 
     expect(entries.length).toBe(1);
     const expectedTtvc = PAGELOAD_DELAY + SCRIPT_DELAY;

--- a/test/e2e/invisible7/index.spec.ts
+++ b/test/e2e/invisible7/index.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {FUDGE} from '../../util/constants';
-import {getEntries} from '../../util/entries';
+import {getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 200;
 const SCRIPT_DELAY = 200;
@@ -12,7 +12,7 @@ test.describe('TTVC', () => {
       waitUntil: 'networkidle',
     });
 
-    const entries = await getEntries(page);
+    const {entries} = await getEntriesAndErrors(page);
 
     expect(entries.length).toBe(1);
     const expectedTtvc = PAGELOAD_DELAY + SCRIPT_DELAY;

--- a/test/e2e/invisible8/index.spec.ts
+++ b/test/e2e/invisible8/index.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {FUDGE} from '../../util/constants';
-import {getEntries} from '../../util/entries';
+import {getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 200;
 const MUTATION_DELAY = 500;
@@ -12,7 +12,7 @@ test.describe('TTVC', () => {
       waitUntil: 'networkidle',
     });
 
-    const entries = await getEntries(page);
+    const {entries} = await getEntriesAndErrors(page);
 
     expect(entries.length).toBe(1);
     const expectedTtvc = PAGELOAD_DELAY + MUTATION_DELAY;

--- a/test/e2e/output1/index.spec.ts
+++ b/test/e2e/output1/index.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {FUDGE} from '../../util/constants';
-import {getEntries} from '../../util/entries';
+import {getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 200;
 const IMAGE_DELAY = 500;
@@ -12,7 +12,7 @@ test.describe('TTVC', () => {
       waitUntil: 'networkidle',
     });
 
-    const entries = await getEntries(page);
+    const {entries} = await getEntriesAndErrors(page);
 
     expect(entries.length).toBe(1);
     expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY + IMAGE_DELAY);
@@ -26,7 +26,7 @@ test.describe('TTVC', () => {
       waitUntil: 'networkidle',
     });
 
-    const entries = await getEntries(page);
+    const {entries} = await getEntriesAndErrors(page);
 
     expect(entries.length).toBe(1);
     expect(entries[0].detail).toBeDefined();

--- a/test/e2e/output2/index.spec.ts
+++ b/test/e2e/output2/index.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {FUDGE} from '../../util/constants';
-import {getEntries} from '../../util/entries';
+import {getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 200;
 
@@ -11,7 +11,7 @@ test.describe('TTVC', () => {
       waitUntil: 'networkidle',
     });
 
-    const entries = await getEntries(page);
+    const {entries} = await getEntriesAndErrors(page);
 
     expect(entries.length).toBe(1);
     expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY);
@@ -25,7 +25,7 @@ test.describe('TTVC', () => {
       waitUntil: 'networkidle',
     });
 
-    const entries = await getEntries(page);
+    const {entries} = await getEntriesAndErrors(page);
 
     expect(entries.length).toBe(1);
     expect(entries[0].detail).toBeDefined();

--- a/test/e2e/prerender1/index.spec.ts
+++ b/test/e2e/prerender1/index.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {FUDGE} from '../../util/constants';
-import {entryCountIs, getEntries} from '../../util/entries';
+import {entryCountIs, getEntriesAndErrors} from '../../util/entries';
 
 test.use({
   // If you run this test headless, you must run with --headless=new to enable prerender2.
@@ -29,7 +29,7 @@ test.describe('TTVC', () => {
     await page.click('a');
 
     await entryCountIs(page, 1);
-    const entries = await getEntries(page);
+    const {entries} = await getEntriesAndErrors(page);
 
     expect(entries[0].duration).toBeGreaterThanOrEqual(1000);
     expect(entries[0].duration).toBeLessThanOrEqual(1000 + FUDGE);
@@ -54,7 +54,7 @@ test.describe('TTVC', () => {
     await page.click('a');
 
     await entryCountIs(page, 1);
-    const entries = await getEntries(page);
+    const {entries} = await getEntriesAndErrors(page);
 
     expect(entries[0].duration).toBeGreaterThanOrEqual(0);
     expect(entries[0].duration).toBeLessThanOrEqual(0 + FUDGE);
@@ -82,7 +82,7 @@ test.describe('TTVC', () => {
     await page.click('a');
 
     await entryCountIs(page, 1);
-    let entries = await getEntries(page);
+    let {entries} = await getEntriesAndErrors(page);
 
     expect(entries[0].duration).toBeGreaterThanOrEqual(0);
     expect(entries[0].duration).toBeLessThanOrEqual(0 + FUDGE);
@@ -92,7 +92,7 @@ test.describe('TTVC', () => {
     await page.click('[data-goto="/about"]');
 
     await entryCountIs(page, 2);
-    entries = await getEntries(page);
+    ({entries} = await getEntriesAndErrors(page));
 
     expect(entries[1].duration).toBe(0);
     expect(entries[1].detail.navigationType).toBe('script');

--- a/test/e2e/react1/index.spec.ts
+++ b/test/e2e/react1/index.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {FUDGE} from '../../util/constants';
-import {getEntries} from '../../util/entries';
+import {getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 200;
 
@@ -11,7 +11,7 @@ test.describe('TTVC', () => {
       waitUntil: 'networkidle',
     });
 
-    const entries = await getEntries(page);
+    const {entries} = await getEntriesAndErrors(page);
 
     expect(entries.length).toBe(1);
     expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY);

--- a/test/e2e/react2/index.spec.ts
+++ b/test/e2e/react2/index.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {FUDGE} from '../../util/constants';
-import {getEntries} from '../../util/entries';
+import {getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 200;
 const IMAGE_DELAY = 500;
@@ -12,7 +12,7 @@ test.describe('TTVC', () => {
       waitUntil: 'networkidle',
     });
 
-    const entries = await getEntries(page);
+    const {entries} = await getEntriesAndErrors(page);
 
     expect(entries.length).toBe(1);
     expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY + IMAGE_DELAY);

--- a/test/e2e/scripts1/index.spec.ts
+++ b/test/e2e/scripts1/index.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {FUDGE} from '../../util/constants';
-import {getEntries} from '../../util/entries';
+import {getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 200;
 const SCRIPT_DELAY = 500;
@@ -12,7 +12,7 @@ test.describe('TTVC', () => {
       waitUntil: 'networkidle',
     });
 
-    const entries = await getEntries(page);
+    const {entries} = await getEntriesAndErrors(page);
 
     expect(entries.length).toBe(1);
     expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY + SCRIPT_DELAY);

--- a/test/e2e/scripts2/index.spec.ts
+++ b/test/e2e/scripts2/index.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {FUDGE} from '../../util/constants';
-import {getEntries} from '../../util/entries';
+import {getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 200;
 const FIRST_SCRIPT_DELAY = 500;
@@ -12,7 +12,7 @@ test.describe('TTVC', () => {
       waitUntil: 'networkidle',
     });
 
-    const entries = await getEntries(page);
+    const {entries} = await getEntriesAndErrors(page);
 
     expect(entries.length).toBe(1);
     expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY + FIRST_SCRIPT_DELAY);

--- a/test/e2e/scripts3/index.spec.ts
+++ b/test/e2e/scripts3/index.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {FUDGE} from '../../util/constants';
-import {getEntries} from '../../util/entries';
+import {getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 200;
 const FIRST_SCRIPT_DELAY = 500;
@@ -12,7 +12,7 @@ test.describe('TTVC', () => {
       waitUntil: 'networkidle',
     });
 
-    const entries = await getEntries(page);
+    const {entries} = await getEntriesAndErrors(page);
 
     expect(entries.length).toBe(1);
     expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY + FIRST_SCRIPT_DELAY);

--- a/test/e2e/scripts4/index.spec.ts
+++ b/test/e2e/scripts4/index.spec.ts
@@ -1,6 +1,6 @@
 import {test, expect} from '@playwright/test';
 
-import {entryCountIs, getEntries} from '../../util/entries';
+import {entryCountIs, getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 200;
 
@@ -11,7 +11,7 @@ test.describe('TTVC', () => {
     });
 
     await entryCountIs(page, 1);
-    const entries = await getEntries(page);
+    const {entries} = await getEntriesAndErrors(page);
 
     // assert that inline resource doesn't cause ttvc to get stuck
     expect(entries.length).toBe(1);

--- a/test/e2e/scripts5/index.spec.ts
+++ b/test/e2e/scripts5/index.spec.ts
@@ -1,6 +1,6 @@
 import {test, expect} from '@playwright/test';
 
-import {entryCountIs, getEntries} from '../../util/entries';
+import {entryCountIs, getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 200;
 
@@ -11,7 +11,7 @@ test.describe('TTVC', () => {
     });
 
     await entryCountIs(page, 1);
-    const entries = await getEntries(page);
+    const {entries} = await getEntriesAndErrors(page);
 
     // assert that this malformed resource doesn't cause ttvc to get stuck
     expect(entries.length).toBe(1);

--- a/test/e2e/spa1/index.spec.ts
+++ b/test/e2e/spa1/index.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {FUDGE} from '../../util/constants';
-import {entryCountIs, getEntries} from '../../util/entries';
+import {entryCountIs, getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 200;
 
@@ -14,7 +14,7 @@ test.describe('TTVC', () => {
     });
 
     test('initial pageload', async ({page}) => {
-      const entries = await getEntries(page);
+      const {entries} = await getEntriesAndErrors(page);
 
       expect(entries.length).toBe(1);
       expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY);
@@ -27,7 +27,7 @@ test.describe('TTVC', () => {
       await page.click('[data-goto="/about"]');
 
       await entryCountIs(page, 2);
-      const entries = await getEntries(page);
+      const {entries} = await getEntriesAndErrors(page);
 
       expect(entries[1].duration).toBeGreaterThanOrEqual(0);
       expect(entries[1].duration).toBeLessThanOrEqual(0 + FUDGE);

--- a/test/e2e/spa2/index.spec.ts
+++ b/test/e2e/spa2/index.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {FUDGE} from '../../util/constants';
-import {entryCountIs, getEntries} from '../../util/entries';
+import {entryCountIs, getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 200;
 const AJAX_DELAY = 500;
@@ -15,7 +15,7 @@ test.describe('TTVC', () => {
     });
 
     test('initial pageload', async ({page}) => {
-      const entries = await getEntries(page);
+      const {entries} = await getEntriesAndErrors(page);
 
       expect(entries.length).toBe(1);
       expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY + AJAX_DELAY);
@@ -28,7 +28,7 @@ test.describe('TTVC', () => {
       await page.click('[data-goto="/about"]');
 
       await entryCountIs(page, 2);
-      const entries = await getEntries(page);
+      const {entries} = await getEntriesAndErrors(page);
 
       expect(entries[1].duration).toBeGreaterThanOrEqual(AJAX_DELAY);
       expect(entries[1].duration).toBeLessThanOrEqual(AJAX_DELAY + FUDGE);
@@ -52,7 +52,7 @@ test.describe('TTVC', () => {
       } catch (e) {
         // pass
       }
-      const entries = await getEntries(page);
+      const {entries} = await getEntriesAndErrors(page);
 
       expect(entries.length).toBe(2);
       expect(entries[1].duration).toBeGreaterThanOrEqual(AJAX_DELAY);

--- a/test/e2e/spa3/index.spec.ts
+++ b/test/e2e/spa3/index.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {FUDGE} from '../../util/constants';
-import {entryCountIs, getEntries} from '../../util/entries';
+import {entryCountIs, getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 200;
 
@@ -14,7 +14,7 @@ test.describe('TTVC', () => {
     });
 
     test('initial pageload', async ({page}) => {
-      const entries = await getEntries(page);
+      const {entries} = await getEntriesAndErrors(page);
 
       expect(entries.length).toBe(1);
       expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY);
@@ -32,7 +32,7 @@ test.describe('TTVC', () => {
       } catch (e) {
         // pass
       }
-      const entries = await getEntries(page);
+      const {entries} = await getEntriesAndErrors(page);
 
       expect(entries.length).toBe(2);
       expect(entries[1].duration).toBeGreaterThanOrEqual(0);

--- a/test/e2e/spa4/index.spec.ts
+++ b/test/e2e/spa4/index.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {FUDGE} from '../../util/constants';
-import {entryCountIs, getEntries} from '../../util/entries';
+import {entryCountIs, getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 200;
 
@@ -14,7 +14,7 @@ test.describe('TTVC', () => {
     });
 
     test('initial pageload', async ({page}) => {
-      const entries = await getEntries(page);
+      const {entries} = await getEntriesAndErrors(page);
 
       expect(entries.length).toBe(1);
       expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY);
@@ -27,7 +27,7 @@ test.describe('TTVC', () => {
       await page.click('[data-goto="/about"]');
 
       await entryCountIs(page, 2);
-      const entries = await getEntries(page);
+      const {entries} = await getEntriesAndErrors(page);
 
       expect(entries[1].duration).toBe(0);
       expect(entries[1].detail.navigationType).toBe('script');

--- a/test/e2e/spa5/index.spec.ts
+++ b/test/e2e/spa5/index.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {FUDGE} from '../../util/constants';
-import {entryCountIs, getEntries} from '../../util/entries';
+import {entryCountIs, getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 200;
 
@@ -14,7 +14,7 @@ test.describe('TTVC', () => {
     });
 
     test('initial pageload', async ({page}) => {
-      const entries = await getEntries(page);
+      const {entries} = await getEntriesAndErrors(page);
 
       expect(entries.length).toBe(1);
       expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY);
@@ -32,7 +32,7 @@ test.describe('TTVC', () => {
       } catch (e) {
         // pass
       }
-      const entries = await getEntries(page);
+      const {entries} = await getEntriesAndErrors(page);
 
       expect(entries.length).toBe(2);
       expect(entries[1].duration).toBeGreaterThanOrEqual(0);

--- a/test/e2e/static1/index.spec.ts
+++ b/test/e2e/static1/index.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {FUDGE} from '../../util/constants';
-import {getEntries} from '../../util/entries';
+import {getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 200;
 
@@ -11,7 +11,7 @@ test.describe('TTVC', () => {
       waitUntil: 'networkidle',
     });
 
-    const entries = await getEntries(page);
+    const {entries} = await getEntriesAndErrors(page);
 
     expect(entries.length).toBe(1);
     expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY);

--- a/test/e2e/stylesheet1/index.spec.ts
+++ b/test/e2e/stylesheet1/index.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {FUDGE} from '../../util/constants';
-import {getEntries} from '../../util/entries';
+import {getEntriesAndErrors} from '../../util/entries';
 
 const PAGELOAD_DELAY = 200;
 const STYLESHEET_DELAY = 500;
@@ -13,7 +13,7 @@ test.describe('TTVC', () => {
       waitUntil: 'networkidle',
     });
 
-    const entries = await getEntries(page);
+    const {entries} = await getEntriesAndErrors(page);
 
     expect(entries.length).toBe(1);
     expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY + STYLESHEET_DELAY);

--- a/test/util/entries.ts
+++ b/test/util/entries.ts
@@ -9,9 +9,6 @@ declare global {
   }
 }
 
-/** Get the list of performance entries that have been recorded from the browser */
-export const getEntries = (page: Page) => page.evaluate(() => window.entries);
-
 /** Get the list of performance entries and errors that have been recorded from the browser */
 export const getEntriesAndErrors = (page: Page) =>
   page.evaluate(() => {


### PR DESCRIPTION
# What is it
In one of the previous PRs (#77), I have introduced `getEntriesAndErrors` as a way to get both errors and measurements for TTVC.

There is likely no point in us keeping both `getEntries` and `getEntriesAndErrors` methods - so I am consolidating the remainder of the tests to use `getEntriesAndErrors`.

### What's the difference?
- `getEntries` returns successful measurements that TTVC has made
- `getEntriesAndErrors` returns both errors/cancellations and succesful measurements

# Testing
No impact on the runtime - only on e2e tests ran with `yarn test:e2e`.