### PR TITLE
Handle iframe with src="about:blank"

### DIFF
--- a/src/networkIdleObservable.ts
+++ b/src/networkIdleObservable.ts
@@ -186,7 +186,7 @@ class ResourceLoadingIdleObservable {
       (element instanceof HTMLImageElement && element.complete) ||
       (element instanceof HTMLLinkElement && !element.href) ||
       (element instanceof HTMLScriptElement && !element.src) ||
-      (element instanceof HTMLIFrameElement && !element.src)
+      (element instanceof HTMLIFrameElement && (!element.src || element.src === 'about:blank'))
     ) {
       return;
     }

--- a/test/e2e/iframe3/index.html
+++ b/test/e2e/iframe3/index.html
@@ -1,0 +1,19 @@
+<head>
+  <script src="/dist/index.min.js"></script>
+  <script src="/analytics.js"></script>
+</head>
+
+<body>
+  <h1 id="h1">Hello world!</h1>
+
+  <script>
+    // <iframe src="/stub.html?delay=500"></iframe>
+    const iframe = document.createElement('iframe');
+    // "src" is technically a required field in HTML iframes. Many libraries work around
+    // this by specifying the url "about:blank".  we should handle this scenario.
+    iframe.src = 'about:blank';
+
+    // append iframe after "load" event fires
+    window.addEventListener('load', () => document.body.appendChild(iframe));
+  </script>
+</body>

--- a/test/e2e/iframe3/index.spec.ts
+++ b/test/e2e/iframe3/index.spec.ts
@@ -1,0 +1,20 @@
+import {test, expect} from '@playwright/test';
+
+import {FUDGE} from '../../util/constants';
+import {getEntries} from '../../util/entries';
+
+const PAGELOAD_DELAY = 200;
+
+test.describe('TTVC', () => {
+  test('an iframe with src="about:blank"', async ({page}) => {
+    await page.goto(`/test/iframe3?delay=${PAGELOAD_DELAY}`, {
+      waitUntil: 'networkidle',
+    });
+
+    const entries = await getEntries(page);
+
+    expect(entries.length).toBe(1);
+    expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY);
+    expect(entries[0].duration).toBeLessThanOrEqual(PAGELOAD_DELAY + FUDGE);
+  });
+});


### PR DESCRIPTION
It seems like some segment of the industry has landed on the use of `src="about:blank"` as a backward compatible alternative to generating an iframe with no `src` attribute.

https://stackoverflow.com/questions/5946607/is-an-empty-iframe-src-valid

https://developer.mozilla.org/en-US/docs/Web/API/HTMLIFrameElement/src

This change ensures that mounting an `<iframe src="about:blank">` will not cause the ResourceIdleObservable class to stall.