### PR TITLE
Starting a new TTVC measurement will now cancel out the previous measurement, if it is still active

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -88,9 +88,9 @@ export const start = () => calculator?.start(performance.now());
  * @dropbox/ttvc that a user interaction has occurred and continuing the
  * measurement may produce an invalid result.
  *
- * @param eventType The type of event that triggered the cancellation. This will be logged to the error callback.
+ * @param e The event that triggered the cancellation. This will be logged to the error callback.
  */
-export const cancel = (eventType?: string) => calculator?.cancel(eventType);
+export const cancel = (e?: Event) => calculator?.cancel(e);
 
 /**
  * Call this to notify ttvc that an AJAX request has just begun.

--- a/test/e2e/cancellation1/index.html
+++ b/test/e2e/cancellation1/index.html
@@ -10,7 +10,7 @@
   <script async src="/stub.js?delay=750"></script>
   <script>
     document.addEventListener('DOMContentLoaded', function () {
-      TTVC.cancel('test_event_type');
+      TTVC.cancel(new Event('test_event_type'));
     });
   </script>
 </body>

--- a/test/e2e/cancellation2/index.html
+++ b/test/e2e/cancellation2/index.html
@@ -10,9 +10,9 @@
   <script async src="/stub.js?delay=750"></script>
   <script>
     document.addEventListener('DOMContentLoaded', function () {
-      TTVC.cancel('test_event_type_1');
+      TTVC.cancel(new Event('test_event_type_1'));
       setTimeout(() => {
-        TTVC.cancel('test_event_type_2');
+        TTVC.cancel(new Event('test_event_type_2'));
       }, 0);
     });
   </script>

--- a/test/e2e/spa6/index.html
+++ b/test/e2e/spa6/index.html
@@ -1,0 +1,51 @@
+<head>
+  <script src="/dist/index.min.js"></script>
+</head>
+
+<body>
+  <h1 id="title"></h1>
+  <ul id="nav">
+    <li><a data-goto="/home" href="#">Home</a></li>
+    <li><a data-goto="/about" href="#">About</a></li>
+  </ul>
+
+  <script src="/analytics.js"></script>
+  <script type="module">
+    import {createHashHistory} from '/node_modules/history/history.production.min.js';
+    const history = createHashHistory();
+
+    // render the title based on current location
+    const render = async () => {
+      const title = document.getElementById('title');
+
+      // simulate data fetching required for route
+      title.innerText = 'Loading...';
+      await fetch('/api?delay=1000');
+
+      title.innerText = {
+        '/home': 'Home',
+        '/about': 'About',
+      }[history.location.pathname];
+    };
+
+    // set initial path to /home
+    history.push('/home');
+    render();
+
+    // set up link click handlers
+    const anchors = document.querySelectorAll('a');
+    anchors.forEach((anchor) => {
+      const url = anchor.dataset.goto;
+      anchor.addEventListener('click', (event) => {
+        event.preventDefault(0);
+        history.push(url);
+      });
+    });
+
+    // handle navigation
+    history.listen(() => {
+      document.documentElement.dispatchEvent(new Event('locationchange', {bubbles: true}));
+      render();
+    });
+  </script>
+</body>

--- a/test/e2e/spa6/index.spec.ts
+++ b/test/e2e/spa6/index.spec.ts
@@ -52,7 +52,7 @@ test.describe('TTVC', () => {
       expect(entries[1].detail.navigationType).toBe('script');
 
       // We expect the interrupted measurement to be ended before the start of the new measurement
-      expect(errors[0].end).toBeLessThanOrEqual(entries[1].start);
+      expect(errors[0].end).toBeLessThanOrEqual(entries[1].start + FUDGE);
       expect(errors[0].duration).toBeGreaterThanOrEqual(INTERACTION_DELAY);
       expect(errors[0].duration).toBeLessThanOrEqual(INTERACTION_DELAY + FUDGE);
       expect(errors[0].cancellationReason).toBe('NEW_MEASUREMENT');

--- a/test/e2e/spa6/index.spec.ts
+++ b/test/e2e/spa6/index.spec.ts
@@ -1,0 +1,61 @@
+import {test, expect} from '@playwright/test';
+
+import {FUDGE} from '../../util/constants';
+import {entryCountIs, getEntriesAndErrors} from '../../util/entries';
+
+const PAGELOAD_DELAY = 200;
+const AJAX_DELAY = 1000;
+const INTERACTION_DELAY = 500;
+
+test.describe('TTVC', () => {
+  test.describe('single page app: hash router + ajax + mutation', () => {
+    test.beforeEach(async ({page}) => {
+      await page.goto(`/test/spa6?delay=${PAGELOAD_DELAY}`, {
+        waitUntil: 'networkidle',
+      });
+    });
+
+    test('initial pageload', async ({page}) => {
+      const {entries} = await getEntriesAndErrors(page);
+
+      expect(entries.length).toBe(1);
+      expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY + AJAX_DELAY);
+      expect(entries[0].duration).toBeLessThanOrEqual(PAGELOAD_DELAY + AJAX_DELAY + FUDGE);
+      expect(entries[0].detail.navigationType).toBe('navigate');
+    });
+
+    test('cancellation of unfinished measurement on new navigation', async ({
+      page,
+      browserName,
+    }) => {
+      // in chromium, the second ajax request runs significantly slower for some reason
+      test.fail(browserName === 'chromium');
+
+      // trigger a navigation
+      await page.click('[data-goto="/about"]');
+
+      // trigger a second navigation *before* the first resolves
+      await page.waitForTimeout(INTERACTION_DELAY);
+      await page.click('[data-goto="/about"]');
+
+      // wait for a possible duplicate entry
+      try {
+        await entryCountIs(page, 3, 2000);
+      } catch (e) {
+        // pass
+      }
+      const {entries, errors} = await getEntriesAndErrors(page);
+
+      expect(entries.length).toBe(2);
+      expect(entries[1].duration).toBeGreaterThanOrEqual(AJAX_DELAY);
+      expect(entries[1].duration).toBeLessThanOrEqual(AJAX_DELAY + FUDGE);
+      expect(entries[1].detail.navigationType).toBe('script');
+
+      // We expect the interrupted measurement to be ended before the start of the new measurement
+      expect(errors[0].end).toBeLessThanOrEqual(entries[1].start);
+      expect(errors[0].duration).toBeGreaterThanOrEqual(INTERACTION_DELAY);
+      expect(errors[0].duration).toBeLessThanOrEqual(INTERACTION_DELAY + FUDGE);
+      expect(errors[0].cancellationReason).toBe('NEW_MEASUREMENT');
+    });
+  });
+});


### PR DESCRIPTION
## What is this
While working on tighter integration of TTVC measurements of "soft" navigations, I have ran into an issue. While it is admittedly an edge case it still warrants a fix: **when a soft navigation occurs before the measurement has had a chance to complete, the interrupted navigation will not be reported entirely correctly.**

The diagram below might help understand the issue:
![ttvc-cancellation-on-soft-navigation](https://github.com/dropbox/ttvc/assets/1320156/c8ed9df8-d8d3-4bbd-a9b8-d36b17062113)
### In this situation:
1. Measurement cancellation will be reported much later compared to when it actually occurred, making integration of TTVC into a host application more confusing
2. Duration of the measurement cancellation will also be incorrect

Along the way, I have also addressed a few edge case scenarios:
1. I have introduced a `NEW_MEASUREMENT` cancellation reason, which is slightly distinct from `NEW_NAVIGATION`. `NEW_NAVIGATION` might mean a navigation to an entirely different site; While `NEW_MEASUREMENT` refers to a new measurement on an existing site.
2. Manual cancellation was not reporting a correct duration, and potentially a wrong navigation type, which will be fixed now

## Testing
- I added a new e2e test case, `spa6`, to test for this scenario.
- Alternatively, run `yarn:express` and hit the `http://localhost:3000/test/spa6#` test case. Wait for a hard navigation to complete. Click one of the links, and immediately click another link. You will see that a cancellation of the first soft navigation TTVC measurement will occur before the second soft navigation.