### PR TITLE
Use Playwright github reporter in CI

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -29,7 +29,9 @@ const config: PlaywrightTestConfig = {
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : 3,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'list',
+  // 'github' for GitHub Actions CI to generate annotations, plus a concise 'dot'
+  // default 'list' when running locally
+  reporter: process.env.CI ? 'github' : 'list',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */


### PR DESCRIPTION
In Github Actions CI, there is no colour which makes "expected failures" (green x in terminal) look like real failures (red x in terminal). Playwright has a built-in `github` reporter and we can conditionally use it in CI as shown in https://playwright.dev/docs/test-reporters#github-actions-annotations

This works more like the `dot` reporter when things are working properly (but only prints an entire row at a time) and adds an annotation to the pull request when there is a failure.

A successful run https://github.com/dropbox/ttvc/actions/runs/9229125586/job/25394647024?pr=89
<img width="1496" alt="image" src="https://github.com/dropbox/ttvc/assets/11243/3ee66f63-86b3-43e0-b3b7-e2e7dd1e7752">

A failure run and inline annotation https://github.com/dropbox/ttvc/actions/runs/9229194092/job/25394874559?pr=89
<img width="1502" alt="image" src="https://github.com/dropbox/ttvc/assets/11243/462c7397-2988-4605-b280-81be44a2c96a">
<img width="1547" alt="image" src="https://github.com/dropbox/ttvc/assets/11243/71c42eaf-de89-4207-93e3-52a4551719e4">