### PR TITLE
Ignore certain <link> tags for resource loading

### DIFF
--- a/src/networkIdleObservable.ts
+++ b/src/networkIdleObservable.ts
@@ -12,14 +12,24 @@ type ResourceLoadingElement =
 // Not all link rels result in a resource download
 // so we keep a set of link rels that we ignore
 const linkRelIgnoreSet: Set<string> = new Set<string>([
+  'alternate',
+  'author',
   'canonical',
-  'preconnect',
   'dns-prefetch',
-  'preload',
-  'modulepreload',
+  'help',
+  'license',
+  'me',
+  'next',
+  'pingback',
+  'preconnect',
   'prefetch',
+  'preload',
   'prerender',
   'preload',
+  'prev',
+  'privacy-policy',
+  'tag',
+  'terms-of-service',
 ]);
 /**
  * Alerts subscribers to the presence or absence of pending AJAX requests

--- a/src/networkIdleObservable.ts
+++ b/src/networkIdleObservable.ts
@@ -9,6 +9,18 @@ type ResourceLoadingElement =
   | HTMLImageElement
   | HTMLIFrameElement;
 
+// Not all link rels result in a resource download
+// so we keep a set of link rels that we ignore
+const linkRelIgnoreSet: Set<string> = new Set<string>([
+  'canonical',
+  'preconnect',
+  'dns-prefetch',
+  'preload',
+  'modulepreload',
+  'prefetch',
+  'prerender',
+  'preload',
+]);
 /**
  * Alerts subscribers to the presence or absence of pending AJAX requests
  *
@@ -109,10 +121,11 @@ class ResourceLoadingIdleObservable {
             mutation.addedNodes.forEach((node) => {
               if (
                 node instanceof HTMLScriptElement ||
-                node instanceof HTMLLinkElement ||
                 node instanceof HTMLImageElement ||
                 node instanceof HTMLIFrameElement
               ) {
+                this.add(node);
+              } else if (node instanceof HTMLLinkElement && !linkRelIgnoreSet.has(node.rel)) {
                 this.add(node);
               } else if (node.hasChildNodes() && node instanceof HTMLElement) {
                 // images may be mounted within large subtrees, this is less

--- a/test/e2e/linkrels1/index.html
+++ b/test/e2e/linkrels1/index.html
@@ -6,7 +6,6 @@
   <link rel="dns-prefetch" href="//example.com">
   <link rel="prefetch" href="/styles.css?delay=1000">
   <link rel="preload" href="/styles.css?delay=1000" as="style">
-  <link rel="modulepreload" href="/busy.js?delay=1000">
   <link rel="prerender" href="/stub.html?delay=1000">
   <link rel="canonical" href="/">
 </head>

--- a/test/e2e/linkrels1/index.html
+++ b/test/e2e/linkrels1/index.html
@@ -1,0 +1,18 @@
+<head>
+  <script src="/dist/index.min.js"></script>
+  <script src="/analytics.js"></script>
+  <!-- Ignored rels should not affect TTVC -->
+  <link rel="preconnect" href="https://example.com">
+  <link rel="dns-prefetch" href="//example.com">
+  <link rel="prefetch" href="/styles.css?delay=1000">
+  <link rel="preload" href="/styles.css?delay=1000" as="style">
+  <link rel="modulepreload" href="/busy.js?delay=1000">
+  <link rel="prerender" href="/stub.html?delay=1000">
+  <link rel="canonical" href="/">
+</head>
+
+<body>
+  <h1 id="h1">Ignored link rels</h1>
+</body>
+
+

--- a/test/e2e/linkrels1/index.spec.ts
+++ b/test/e2e/linkrels1/index.spec.ts
@@ -1,0 +1,24 @@
+import {test, expect} from '@playwright/test';
+
+import {FUDGE} from '../../util/constants';
+import {getEntriesAndErrors} from '../../util/entries';
+
+const PAGELOAD_DELAY = 200;
+
+test.describe('TTVC - ignored link rels', () => {
+  test('ignored link rels do not delay TTVC', async ({page}) => {
+    await page.goto(`/test/linkrels1?delay=${PAGELOAD_DELAY}`, {
+      waitUntil: 'networkidle',
+    });
+
+    const {entries, errors} = await getEntriesAndErrors(page);
+
+    // should produce a single entry, and duration should be ~= pageload delay
+    expect(errors.length).toBe(0);
+    expect(entries.length).toBe(1);
+    expect(entries[0].duration).toBeGreaterThanOrEqual(PAGELOAD_DELAY);
+    expect(entries[0].duration).toBeLessThanOrEqual(PAGELOAD_DELAY + FUDGE);
+  });
+});
+
+

--- a/test/unit/resourceLoadingIdleObservable.jest.ts
+++ b/test/unit/resourceLoadingIdleObservable.jest.ts
@@ -1,0 +1,75 @@
+import {NetworkIdleObservable} from '../../src/networkIdleObservable';
+import {CONFIG} from '../../src/util/constants';
+
+const wait = async (ms: number) => new Promise((resolve) => window.setTimeout(resolve, ms));
+
+describe('ResourceLoadingIdleObservable - link rel ignore behavior', () => {
+  let networkIdleObservable: NetworkIdleObservable;
+  let unsubscribe: () => void;
+  let subscriber: jest.Mock;
+
+  beforeEach(() => {
+    // disable cleanup timeout to avoid side-effects in tests
+    CONFIG.NETWORK_TIMEOUT = 0;
+    networkIdleObservable = new NetworkIdleObservable();
+    subscriber = jest.fn();
+    unsubscribe = networkIdleObservable.subscribe(subscriber);
+
+    // trigger initialization of MutationObserver and event listeners
+    window.dispatchEvent(new Event('load'));
+  });
+
+  afterEach(() => {
+    unsubscribe();
+  });
+
+  it.each([
+    'canonical',
+    'preconnect',
+    'dns-prefetch',
+    'preload',
+    'modulepreload',
+    'prefetch',
+    'prerender',
+  ])('ignores <link rel="%s"> when tracking network idleness', async (rel) => {
+    const link = document.createElement('link');
+    link.rel = rel;
+    link.href = '/ignored-resource.css';
+    document.head.appendChild(link);
+
+    // allow MutationObserver to process the DOM change
+    await wait(0);
+
+    expect(networkIdleObservable.isIdle()).toBe(true);
+    expect(subscriber).toHaveBeenCalledTimes(0);
+  });
+
+  it('tracks non-ignored <link rel="stylesheet"> as a pending resource', async () => {
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = '/styles.css';
+    document.head.appendChild(link);
+
+    // allow MutationObserver to process the DOM change
+    await wait(0);
+
+    // should report busy
+    expect(networkIdleObservable.isIdle()).toBe(false);
+    expect(subscriber).toHaveBeenCalledTimes(1);
+    expect(subscriber).toHaveBeenLastCalledWith('BUSY');
+
+    // simulate the resource finishing
+    const loadEvent = new Event('load', {bubbles: true});
+    Object.defineProperty(loadEvent, 'target', {value: link});
+    document.dispatchEvent(loadEvent);
+
+    // allow event listener to run
+    await wait(0);
+
+    expect(networkIdleObservable.isIdle()).toBe(true);
+    expect(subscriber).toHaveBeenCalledTimes(2);
+    expect(subscriber).toHaveBeenLastCalledWith('IDLE');
+  });
+});
+
+

--- a/test/unit/resourceLoadingIdleObservable.jest.ts
+++ b/test/unit/resourceLoadingIdleObservable.jest.ts
@@ -24,13 +24,24 @@ describe('ResourceLoadingIdleObservable - link rel ignore behavior', () => {
   });
 
   it.each([
+    'alternate',
+    'author',
     'canonical',
-    'preconnect',
     'dns-prefetch',
-    'preload',
-    'modulepreload',
+    'help',
+    'license',
+    'me',
+    'next',
+    'pingback',
+    'preconnect',
     'prefetch',
+    'preload',
     'prerender',
+    'preload',
+    'prev',
+    'privacy-policy',
+    'tag',
+    'terms-of-service',
   ])('ignores <link rel="%s"> when tracking network idleness', async (rel) => {
     const link = document.createElement('link');
     link.rel = rel;


### PR DESCRIPTION
This PR makes it so TTVC no longer considers certain <link> resources as the ones that need to be tracked.
This is because certain links do not result in a download, so TTVC ends up waiting until the 'network timeout'.

We have discovered it by having a page that does <link rel='canonical'> 