### PR TITLE
Fix for async loading of TTVC lib

### DIFF
--- a/test/e2e/late-load/index.html
+++ b/test/e2e/late-load/index.html
@@ -5,20 +5,24 @@
     window.addEventListener('load', function () {
       // small delay so load has definitely finished
       setTimeout(() => {
-        const ttvc = document.createElement('script');
-        ttvc.src = '/dist/index.min.js';
-        document.head.appendChild(ttvc);
-
         const analytics = document.createElement('script');
         analytics.src = '/analytics.js';
         // when analytics is ready, add a resource that should be tracked
         analytics.onload = () => {
           // add an image that loads with a delay so it would normally be observed
+          console.log('Analytics script loaded');
           const img = document.createElement('img');
           img.src = '/150.png?delay=500';
           document.body.appendChild(img);
         };
-        document.head.appendChild(analytics);
+
+        const ttvc = document.createElement('script');
+        ttvc.src = '/dist/index.min.js';
+        document.head.appendChild(ttvc);
+        ttvc.onload = () => {
+          console.log('TTVC script loaded');
+          document.head.appendChild(analytics);
+        };
       }, 50);
     });
   </script>

--- a/test/e2e/late-load/index.html
+++ b/test/e2e/late-load/index.html
@@ -1,0 +1,29 @@
+<head>
+  <!-- Deliberately do NOT include /dist/index.min.js here. Instead we append it after the window 'load' event to reproduce the failure mode -->
+  <script>
+    // after the real window 'load' fires, append TTVC and analytics, then add a delayed image
+    window.addEventListener('load', function () {
+      // small delay so load has definitely finished
+      setTimeout(() => {
+        const ttvc = document.createElement('script');
+        ttvc.src = '/dist/index.min.js';
+        document.head.appendChild(ttvc);
+
+        const analytics = document.createElement('script');
+        analytics.src = '/analytics.js';
+        // when analytics is ready, add a resource that should be tracked
+        analytics.onload = () => {
+          // add an image that loads with a delay so it would normally be observed
+          const img = document.createElement('img');
+          img.src = '/150.png?delay=500';
+          document.body.appendChild(img);
+        };
+        document.head.appendChild(analytics);
+      }, 50);
+    });
+  </script>
+</head>
+
+<body>
+  <h1>late load test</h1>
+</body>

--- a/test/e2e/late-load/index.spec.ts
+++ b/test/e2e/late-load/index.spec.ts
@@ -1,0 +1,21 @@
+import {expect, test} from '@playwright/test';
+
+import {getEntriesAndErrors} from '../../util/entries';
+
+test.describe('TTVC late load', () => {
+  test('library loaded after window.load should miss resource tracking', async ({page}) => {
+    // navigate and wait for the page load to fire (our page appends TTVC after load)
+    await page.goto(`/test/late-load`, {waitUntil: 'load'});
+
+    // wait long enough for scripts to be appended and the delayed image to load
+    await page.waitForTimeout(1200);
+
+    const {entries, errors} = await getEntriesAndErrors(page);
+
+    // We expect TTVC to track resource downloads even when loaded late. This
+    // assertion is intentionally strict so the test fails today and will pass
+    // once the underlying library is fixed to handle late initialisation.
+    expect(entries.length).toBe(1);
+    expect(errors.length).toBe(0);
+  });
+});


### PR DESCRIPTION
This PR addresses the issue where ttvc is loaded into an SPA after the window.load has fired.

In the current state that means the observer for the resources never registers.

This is already properly handled in the `waitForPageLoad` called from `visuallyCompleteCalculator`, we check the `document.readyState` and immediately resolve if it is complete. But it was not handled for the networkIdleObservable.

I have added the test that validates this behavior. Without the fix it marks ttvc before the img is ever downloaded. 

Obviously there is still a gap if the resource started downloading before ttvc was initialized, but at least this way ttvc will work for future SPA navigations. Without this fix any future resources (e.g. additional bundles) are also not tracked.